### PR TITLE
Fix build script and enhance service worker for asset management

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "time-pilot",
-  "version": "18.31.0",
+  "version": "18.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "time-pilot",
-      "version": "18.31.0",
+      "version": "18.32.0",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "time-pilot",
   "private": true,
-  "version": "18.31.0",
+  "version": "18.32.0",
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc -b && vite build && node scripts/prune-release-assets.mjs",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit --noImplicitAny true",
     "test": "vitest run",

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,9 +1,11 @@
-const CACHE_NAME = "time-pilot-v4";
+const CACHE_NAME = "time-pilot-v5";
 const APP_SHELL = [
   "./",
   "./index.html",
   "./pwa/",
   "./pwa/index.html",
+  "./assets/app.css",
+  "./assets/main.js",
   "./manifest.webmanifest",
   "./pwa-icon-512.png",
   "./pwa-icon.svg",
@@ -126,6 +128,41 @@ const networkFirst = async (request) => {
   }
 };
 
+const getLegacyEntryAssetFallback = async (request) => {
+  const url = new URL(request.url);
+  const fallbackPath = url.pathname.endsWith(".css")
+    ? "./assets/app.css"
+    : url.pathname.endsWith(".js")
+      ? "./assets/main.js"
+      : "";
+
+  if (!fallbackPath || !/\/assets\/main-[^/]+\.(css|js)$/.test(url.pathname)) {
+    return undefined;
+  }
+
+  const cachedResponse = await caches.match(fallbackPath);
+
+  if (cachedResponse) {
+    return cachedResponse;
+  }
+
+  try {
+    return await fetch(fallbackPath);
+  } catch {
+    return undefined;
+  }
+};
+
+const networkFirstEntryAsset = async (request) => {
+  const response = await networkFirst(request);
+
+  if (response.ok) {
+    return response;
+  }
+
+  return (await getLegacyEntryAssetFallback(request)) ?? response;
+};
+
 const getNavigationFallback = async (request) => {
   const url = new URL(request.url);
   const fallbackPath = url.pathname.includes("/pwa/")
@@ -167,6 +204,11 @@ self.addEventListener("fetch", (event) => {
         throw new Error(`No offline page available for ${event.request.url}`);
       })
     );
+    return;
+  }
+
+  if (["script", "style"].includes(event.request.destination)) {
+    event.respondWith(networkFirstEntryAsset(event.request));
     return;
   }
 

--- a/scripts/prune-release-assets.mjs
+++ b/scripts/prune-release-assets.mjs
@@ -1,0 +1,27 @@
+import { readdirSync, rmSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const releaseDir = "dist";
+const excludedFiles = [/\.psd$/i, /^\.DS_Store$/i];
+
+const pruneDirectory = (directory) => {
+  for (const entry of readdirSync(directory)) {
+    const path = join(directory, entry);
+    const stats = statSync(path);
+
+    if (stats.isDirectory()) {
+      pruneDirectory(path);
+
+      if (readdirSync(path).length === 0) {
+        rmSync(path, { recursive: true });
+      }
+      continue;
+    }
+
+    if (excludedFiles.some((pattern) => pattern.test(entry))) {
+      rmSync(path);
+    }
+  }
+};
+
+pruneDirectory(releaseDir);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,6 +24,14 @@ export default defineConfig({
         main: path.resolve(dirname, "index.html"),
         pwa: path.resolve(dirname, "pwa/index.html"),
       },
+      output: {
+        assetFileNames: (assetInfo) =>
+          assetInfo.names.some((name) => name.endsWith(".css"))
+            ? "assets/app.css"
+            : "assets/[name][extname]",
+        chunkFileNames: "assets/[name].js",
+        entryFileNames: "assets/app.js",
+      },
     },
   },
   server: {


### PR DESCRIPTION
This pull request introduces improvements to the asset build process and enhances service worker handling for static assets. The main changes focus on producing stable asset filenames for CSS and JS, adding a script to clean up unwanted files from the release output, and updating the service worker to better handle asset requests and fallbacks.

**Build output and asset management:**

* The Vite build output is now configured to use stable filenames for main CSS (`assets/app.css`) and JS (`assets/app.js`) files, making asset references predictable and simplifying cache management.
* A new script, `scripts/prune-release-assets.mjs`, is added to the build process to automatically remove unnecessary files (like `.psd` and `.DS_Store`) from the `dist` directory after each build.
* The `build` script in `package.json` is updated to run the new pruning script after building.

**Service worker enhancements:**

* The service worker's cache version is bumped and the app shell now explicitly includes the new stable asset filenames (`assets/app.css`, `assets/main.js`).
* A fallback mechanism is added to the service worker to serve the stable asset files (`app.css`, `main.js`) if a request for a hashed entry asset fails, improving resilience to deployment mismatches or cache issues.
* The service worker now routes all `script` and `style` requests through this new fallback mechanism.