### PR TITLE
Refactor preroll logo sizing and ship rendering calculations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "time-pilot",
-  "version": "18.66.0",
+  "version": "18.67.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "time-pilot",
-      "version": "18.66.0",
+      "version": "18.67.0",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "time-pilot",
   "private": true,
-  "version": "18.66.0",
+  "version": "18.67.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/game/preroll.ts
+++ b/src/game/preroll.ts
@@ -13,7 +13,7 @@ type PrerollOptions = {
 
 const authorLogoFadeMs = 800;
 const authorLogoHoldMs = 1500;
-const authorLogoSize = 512;
+const authorLogoViewportRatio = 0.5;
 const logoFadeMs = 800;
 const shipFlyDurationMs = 1500;
 const postFlyoutHoldMs = 1000;
@@ -28,7 +28,6 @@ const logoSourceWidth = 420;
 const logoSourceHeight = 96;
 const logoPerspectiveHeight = 86;
 const logoPerspectiveBottomWidth = 390;
-const shipRenderSize = player.width * 3;
 const timePilotStartMs = authorLogoFadeMs + authorLogoHoldMs + authorLogoFadeMs;
 
 class Preroll {
@@ -148,7 +147,8 @@ class Preroll {
         : elapsed >= fadeOutStartMs
           ? 1 - (elapsed - fadeOutStartMs) / authorLogoFadeMs
           : 1;
-    const size = Math.min(authorLogoSize, this.arena.width * 0.9, this.arena.height * 0.9);
+    const size =
+      Math.min(this.arena.width, this.arena.height) * authorLogoViewportRatio;
 
     context.save();
     context.globalAlpha *= Math.max(0, Math.min(1, alpha));
@@ -187,6 +187,7 @@ class Preroll {
     flyElapsedMs: number
   ): void => {
     const progress = Math.max(0, Math.min(1, flyElapsedMs / shipFlyDurationMs));
+    const shipRenderSize = this.getFlybyShipRenderSize();
     const startX = -this.arena.width / 2 - shipRenderSize / 2;
     const endX = this.arena.width / 2 + shipRenderSize / 2;
     const x = this.lerp(startX, endX, progress);
@@ -227,6 +228,9 @@ class Preroll {
       (this.arena.width * 0.8) / logoPerspectiveBottomWidth,
       (this.arena.height * 0.9) / logoPerspectiveHeight
     );
+
+  private getFlybyShipRenderSize = (): number =>
+    (logoPerspectiveHeight * this.getInitialLogoScale()) / 2;
 
   private getMenuScale = (): number => {
     const availableWidth = Math.max(1, this.arena.width - menuEdgePadding * 2);


### PR DESCRIPTION
This pull request updates the sizing logic for the preroll author logo and the flyby ship in the game intro to make both scale more responsively based on the viewport size, rather than using fixed pixel values. This ensures a more consistent appearance across different screen sizes.

**Responsive sizing improvements:**

* The author logo size is now dynamically calculated as a ratio of the smaller viewport dimension, controlled by the new `authorLogoViewportRatio` constant, instead of the fixed `authorLogoSize` value. [[1]](diffhunk://#diff-4c38dc525ced9cc5b30667d99d17e45ffb3d338d2b19d705438b6445980044c6L16-R16) [[2]](diffhunk://#diff-4c38dc525ced9cc5b30667d99d17e45ffb3d338d2b19d705438b6445980044c6L151-R151)
* The flyby ship render size is now computed via the new `getFlybyShipRenderSize` method, making it scale proportionally with the logo and viewport, instead of relying on a fixed multiplier of `player.width`. [[1]](diffhunk://#diff-4c38dc525ced9cc5b30667d99d17e45ffb3d338d2b19d705438b6445980044c6L31) [[2]](diffhunk://#diff-4c38dc525ced9cc5b30667d99d17e45ffb3d338d2b19d705438b6445980044c6R190) [[3]](diffhunk://#diff-4c38dc525ced9cc5b30667d99d17e45ffb3d338d2b19d705438b6445980044c6R232-R234)

**Version update:**

* Bumped the project version from `18.66.0` to `18.67.0` in `package.json` to reflect these changes.