### PR TITLE
Bug: add fallback message for app exit when blocked on Android PWA

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,9 @@ followed by the player time-warp animation and a reload.
 
 When the game is running as an installed PWA, the root menu also shows an
 `Exit` action. It asks the browser to close the app window; platforms that do
-not allow scripted app closure may ignore the request.
+not allow scripted app closure may ignore the request. If that happens, Time
+Pilot confirms the run has been saved and tells the player to leave with the
+device Home or Back button.
 
 Installed PWA options also include `Keep Screen Awake`. It is enabled by
 default and uses the browser Screen Wake Lock API during active or paused player

--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -129,7 +129,8 @@
   override, and request fullscreen/landscape presentation from the player's
   Start/Continue action on the `/pwa/` route.
 - Added an installed-PWA-only root-menu Exit action that asks the browser to
-  close the app window where the platform allows it.
+  close the app window where the platform allows it, with a saved-state fallback
+  message when Android keeps the app open.
 - Added an installed-PWA-only Keep Screen Awake option, enabled by default,
   that uses the Screen Wake Lock API during active or paused player runs.
 - Moved the controls overlay toggle into Options and hid the unfinished Control

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "time-pilot",
-  "version": "19.7.0",
+  "version": "19.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "time-pilot",
-      "version": "19.7.0",
+      "version": "19.8.0",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "time-pilot",
   "private": true,
-  "version": "19.7.0",
+  "version": "19.8.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/TimePilotGame.tsx
+++ b/src/components/TimePilotGame.tsx
@@ -7,7 +7,7 @@ import {
   useState,
   type CSSProperties,
 } from "react";
-import { exitInstalledApp } from "../game/app-exit";
+import { appExitBlockedEvent, exitInstalledApp } from "../game/app-exit";
 import { getFilterSettingsForMode } from "../game/filter-settings";
 import { enterGameFullscreen } from "../game/immersive-mode";
 import {
@@ -76,6 +76,7 @@ function TimePilotGame({
   const [updateOverlayState, setUpdateOverlayState] = useState<
     "idle" | "updating" | "warping"
   >("idle");
+  const [isExitFallbackVisible, setIsExitFallbackVisible] = useState(false);
   const applyUpdateRef = useRef<() => void>(() => {});
   const isUpdateAvailableRef = useRef(false);
   const updateOverlayStateRef = useRef(updateOverlayState);
@@ -160,6 +161,22 @@ function TimePilotGame({
   useEffect(() => {
     updateOverlayStateRef.current = updateOverlayState;
   }, [updateOverlayState]);
+
+  useEffect(() => {
+    if (!enableAppExit) {
+      return;
+    }
+
+    const handleAppExitBlocked = (): void => {
+      setIsExitFallbackVisible(true);
+    };
+
+    window.addEventListener(appExitBlockedEvent, handleAppExitBlocked);
+
+    return () => {
+      window.removeEventListener(appExitBlockedEvent, handleAppExitBlocked);
+    };
+  }, [enableAppExit]);
 
   useEffect(() => {
     if (!enableScreenWakeLock || !canUseScreenWakeLock()) {
@@ -275,6 +292,23 @@ function TimePilotGame({
           onWarpComplete={handleUpdateWarpComplete}
           state={updateOverlayState}
         />
+      ) : null}
+      {enableAppExit && isExitFallbackVisible ? (
+        <div className={"time-pilot-exit-fallback"} role={"status"}>
+          <div className={"time-pilot-exit-fallback-panel"}>
+            <h2>Game Saved</h2>
+            <p>
+              Android has kept the app open. Use your device Home or Back button
+              to leave Time Pilot; your current run will be restored next time.
+            </p>
+            <button
+              type={"button"}
+              onClick={() => setIsExitFallbackVisible(false)}
+            >
+              Return to Game
+            </button>
+          </div>
+        </div>
       ) : null}
     </div>
   );

--- a/src/components/__tests__/TimePilotGame.test.tsx
+++ b/src/components/__tests__/TimePilotGame.test.tsx
@@ -122,4 +122,31 @@ describe("TimePilotGame", () => {
 
     expect(container.querySelector(".time-pilot-update-overlay")).toBeNull();
   });
+
+  it("shows a saved fallback when installed app exit is blocked", async () => {
+    await act(async () => {
+      root.render(<TimePilotGame debug enableAppExit />);
+      await new Promise((resolve) => window.setTimeout(resolve, 5));
+    });
+
+    await act(async () => {
+      window.dispatchEvent(new CustomEvent("timePilot:appExitBlocked"));
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector('[role="status"]')?.textContent).toContain(
+      "Game Saved"
+    );
+
+    await act(async () => {
+      container.querySelector("button")?.dispatchEvent(
+        new MouseEvent("click", {
+          bubbles: true,
+        })
+      );
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector(".time-pilot-exit-fallback")).toBeNull();
+  });
 });

--- a/src/game/app-exit.ts
+++ b/src/game/app-exit.ts
@@ -1,9 +1,26 @@
 /**
+ * Event dispatched when the browser appears to have refused app closure.
+ */
+export const appExitBlockedEvent = "timePilot:appExitBlocked";
+
+/**
  * Requests that the installed app window closes.
  *
- * Browser support is intentionally limited; Android installed PWAs may honour
- * this from a user gesture, while normal browser tabs usually ignore it.
+ * Browser support is intentionally limited. Android installed PWAs and normal
+ * browser tabs commonly ignore {@link Window.close}; if the document remains
+ * visible shortly after the request, callers are notified so they can show a
+ * useful fallback instead of leaving the Exit action feeling broken.
  */
 export const exitInstalledApp = (): void => {
-  window.close();
+  try {
+    window.close();
+  } finally {
+    window.setTimeout(() => {
+      if (document.visibilityState === "hidden") {
+        return;
+      }
+
+      window.dispatchEvent(new CustomEvent(appExitBlockedEvent));
+    }, 300);
+  }
 };

--- a/src/styles.css
+++ b/src/styles.css
@@ -256,6 +256,50 @@ input {
   image-rendering: pixelated;
 }
 
+.time-pilot-exit-fallback {
+  position: fixed;
+  inset: 0;
+  z-index: 10001;
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+  background: rgba(0, 0, 0, 0.84);
+  color: #f8fbff;
+}
+
+.time-pilot-exit-fallback-panel {
+  width: min(28rem, 100%);
+  padding: 1.25rem;
+  border: 2px solid #f4c14f;
+  background: #071120;
+  box-shadow: 0 0 0 2px #17395d;
+  text-align: center;
+}
+
+.time-pilot-exit-fallback-panel h2 {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.time-pilot-exit-fallback-panel p {
+  margin: 0;
+  color: #d8e7f8;
+  line-height: 1.5;
+}
+
+.time-pilot-exit-fallback-panel button {
+  margin-top: 1rem;
+  padding: 0.625rem 0.875rem;
+  border: 2px solid #f4c14f;
+  background: #f4c14f;
+  color: #071120;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
 .time-pilot-update-status-text {
   position: absolute;
   width: 1px;


### PR DESCRIPTION
This pull request improves the installed PWA experience by handling cases where the browser blocks the app exit request. Now, if the app cannot be closed programmatically (common on Android), the player receives a clear confirmation that their run is saved and instructions to exit using the device's Home or Back button. The update includes UI changes, event handling, and documentation updates.

**User experience improvements:**

* Added a fallback overlay in `TimePilotGame` that appears when the app exit request is blocked, informing the player that their run is saved and instructing them to leave using device controls (`src/components/TimePilotGame.tsx`, `src/styles.css`). [[1]](diffhunk://#diff-1052c9ab63dc04f6fb9afeff49639c54be7badc9aec053694f6d184943d7798aR296-R312) [[2]](diffhunk://#diff-4753b2e6427841425517139f09f1342c320338443447af46169dc0f43a0f2cf3R259-R302)
* Updated documentation and release notes to describe the new fallback behavior for blocked app exits (`README.md`, `WHATSNEW.md`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L82-R84) [[2]](diffhunk://#diff-fcb406334dd4e4044d79513136b7baf79ba53664ba041dc46a01fffefe8eb200L132-R133)

**Technical changes:**

* Introduced the `appExitBlockedEvent` custom event, dispatched if the app remains visible after an exit attempt, allowing the UI to respond appropriately (`src/game/app-exit.ts`).
* Updated the `exitInstalledApp` logic to detect and signal when the app was not closed (`src/game/app-exit.ts`).
* Added a test to verify the fallback overlay appears and dismisses correctly when app exit is blocked (`src/components/__tests__/TimePilotGame.test.tsx`).

**Other:**

* Bumped the app version to `19.8.0` in `package.json`.