### PR TITLE
Bug/fixes 3

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -8,6 +8,7 @@
       content="About Time Pilot, a free privacy-minded pixel-art arcade rebuild by Rob."
     />
     <meta name="theme-color" content="#070b12" />
+    <meta http-equiv="X-Clacks-Overhead" content="GNU Terry Pratchett" />
     <meta name="application-name" content="Time Pilot" />
     <link rel="manifest" href="../manifest.webmanifest?v=%TIME_PILOT_VERSION%" />
     <link rel="icon" type="image/png" sizes="192x192" href="../pwa-icon-192.png" />

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
       content="Play Time Pilot, a React and TypeScript pixel-art arcade prototype with keyboard, gamepad, touch controls, installable offline PWA support, localized menus, and adjustable video, UI, and game zoom options."
     />
     <meta name="theme-color" content="#070b12" />
+    <meta http-equiv="X-Clacks-Overhead" content="GNU Terry Pratchett" />
     <meta name="application-name" content="Time Pilot" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "time-pilot",
-  "version": "20.1.0",
+  "version": "20.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "time-pilot",
-      "version": "20.1.0",
+      "version": "20.2.0",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "time-pilot",
-  "version": "20.0.0",
+  "version": "20.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "time-pilot",
-      "version": "20.0.0",
+      "version": "20.1.0",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "time-pilot",
   "private": true,
-  "version": "20.0.0",
+  "version": "20.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "time-pilot",
   "private": true,
-  "version": "20.1.0",
+  "version": "20.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,9 +1,11 @@
-const CACHE_NAME = "time-pilot-v5";
+const CACHE_NAME = "time-pilot-v6";
 const CLACKS_HEADER_NAME = "X-Clacks-Overhead";
 const CLACKS_HEADER_VALUE = "GNU Terry Pratchett";
 const APP_SHELL = [
   "./",
   "./index.html",
+  "./about/",
+  "./about/index.html",
   "./pwa/",
   "./pwa/index.html",
   "./assets/app.css",
@@ -194,9 +196,13 @@ const networkFirstEntryAsset = async (request) => {
 
 const getNavigationFallback = async (request) => {
   const url = new URL(request.url);
+  const isAboutRoute =
+    url.pathname.endsWith("/about") || url.pathname.includes("/about/");
   const fallbackPath = url.pathname.includes("/pwa/")
     ? "./pwa/index.html"
-    : "./index.html";
+    : isAboutRoute
+      ? "./about/index.html"
+      : "./index.html";
 
   const response =
     (await caches.match(request)) ??

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,4 +1,6 @@
 const CACHE_NAME = "time-pilot-v5";
+const CLACKS_HEADER_NAME = "X-Clacks-Overhead";
+const CLACKS_HEADER_VALUE = "GNU Terry Pratchett";
 const APP_SHELL = [
   "./",
   "./index.html",
@@ -17,6 +19,21 @@ const APP_SHELL = [
   "./screenshots/time-pilot-preroll-flyby.png",
   "./screenshots/time-pilot-root-menu.png",
 ];
+
+const withClacksHeader = (response) => {
+  if (!response || response.type === "opaque") {
+    return response;
+  }
+
+  const headers = new Headers(response.headers);
+  headers.set(CLACKS_HEADER_NAME, CLACKS_HEADER_VALUE);
+
+  return new Response(response.body, {
+    headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
+};
 const GAME_ASSETS = [
   "./fonts/font.ttf",
   "./music/level1.ogg",
@@ -108,6 +125,7 @@ self.addEventListener("activate", (event) => {
 
 const cacheResponse = async (request, response) => {
   const url = new URL(request.url);
+  const clacksResponse = withClacksHeader(response);
 
   if (
     !response ||
@@ -116,12 +134,12 @@ const cacheResponse = async (request, response) => {
     url.origin !== self.location.origin ||
     !["http:", "https:"].includes(url.protocol)
   ) {
-    return response;
+    return clacksResponse;
   }
 
   const cache = await caches.open(CACHE_NAME);
-  await cache.put(request, response.clone());
-  return response;
+  await cache.put(request, clacksResponse.clone());
+  return clacksResponse;
 };
 
 const networkFirst = async (request) => {
@@ -132,7 +150,7 @@ const networkFirst = async (request) => {
     const cachedResponse = await caches.match(request);
 
     if (cachedResponse) {
-      return cachedResponse;
+      return withClacksHeader(cachedResponse);
     }
 
     throw new Error(`No cached response available for ${request.url}`);
@@ -154,11 +172,11 @@ const getLegacyEntryAssetFallback = async (request) => {
   const cachedResponse = await caches.match(fallbackPath);
 
   if (cachedResponse) {
-    return cachedResponse;
+    return withClacksHeader(cachedResponse);
   }
 
   try {
-    return await fetch(fallbackPath);
+    return withClacksHeader(await fetch(fallbackPath));
   } catch {
     return undefined;
   }
@@ -180,7 +198,12 @@ const getNavigationFallback = async (request) => {
     ? "./pwa/index.html"
     : "./index.html";
 
-  return caches.match(request) ?? caches.match(fallbackPath) ?? caches.match("./");
+  const response =
+    (await caches.match(request)) ??
+    (await caches.match(fallbackPath)) ??
+    (await caches.match("./"));
+
+  return withClacksHeader(response);
 };
 
 const staleWhileRevalidate = async (request) => {
@@ -192,7 +215,7 @@ const staleWhileRevalidate = async (request) => {
   const response = cachedResponse ?? (await networkResponse);
 
   if (response) {
-    return response;
+    return withClacksHeader(response);
   }
 
   throw new Error(`No cached response available for ${request.url}`);

--- a/pwa/index.html
+++ b/pwa/index.html
@@ -8,6 +8,7 @@
       content="Play Time Pilot as a full-screen pixel-art arcade game."
     />
     <meta name="theme-color" content="#070b12" />
+    <meta http-equiv="X-Clacks-Overhead" content="GNU Terry Pratchett" />
     <meta name="application-name" content="Time Pilot" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/src/components/TimePilotGame.tsx
+++ b/src/components/TimePilotGame.tsx
@@ -79,6 +79,7 @@ function TimePilotGame({
   const [isExitFallbackVisible, setIsExitFallbackVisible] = useState(false);
   const applyUpdateRef = useRef<() => void>(() => {});
   const isUpdateAvailableRef = useRef(false);
+  const exitFallbackButtonRef = useRef<HTMLButtonElement | null>(null);
   const updateOverlayStateRef = useRef(updateOverlayState);
   const wakeLockControllerRef = useRef<ScreenWakeLockController | null>(null);
   const rgbSplitFilterId = useId().replace(/:/g, "");
@@ -161,6 +162,14 @@ function TimePilotGame({
   useEffect(() => {
     updateOverlayStateRef.current = updateOverlayState;
   }, [updateOverlayState]);
+
+  useEffect(() => {
+    if (!isExitFallbackVisible) {
+      return;
+    }
+
+    exitFallbackButtonRef.current?.focus();
+  }, [isExitFallbackVisible]);
 
   useEffect(() => {
     if (!enableAppExit) {
@@ -294,14 +303,20 @@ function TimePilotGame({
         />
       ) : null}
       {enableAppExit && isExitFallbackVisible ? (
-        <div className={"time-pilot-exit-fallback"} role={"status"}>
+        <div
+          aria-labelledby={"time-pilot-exit-fallback-title"}
+          aria-modal={"true"}
+          className={"time-pilot-exit-fallback"}
+          role={"dialog"}
+        >
           <div className={"time-pilot-exit-fallback-panel"}>
-            <h2>Game Saved</h2>
+            <h2 id={"time-pilot-exit-fallback-title"}>Game Saved</h2>
             <p>
               Android has kept the app open. Use your device Home or Back button
               to leave Time Pilot; your current run will be restored next time.
             </p>
             <button
+              ref={exitFallbackButtonRef}
               type={"button"}
               onClick={() => setIsExitFallbackVisible(false)}
             >

--- a/src/components/__tests__/TimePilotGame.test.tsx
+++ b/src/components/__tests__/TimePilotGame.test.tsx
@@ -1,6 +1,7 @@
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { appExitBlockedEvent } from "../../game/app-exit";
 import userOptions from "../../game/user-options";
 import TimePilotGame from "../TimePilotGame";
 import UpdateOverlay from "../UpdateOverlay";
@@ -130,16 +131,18 @@ describe("TimePilotGame", () => {
     });
 
     await act(async () => {
-      window.dispatchEvent(new CustomEvent("timePilot:appExitBlocked"));
+      window.dispatchEvent(new CustomEvent(appExitBlockedEvent));
       await Promise.resolve();
     });
 
-    expect(container.querySelector('[role="status"]')?.textContent).toContain(
-      "Game Saved"
-    );
+    const dialog = container.querySelector(".time-pilot-exit-fallback");
+
+    expect(dialog?.getAttribute("role")).toBe("dialog");
+    expect(dialog?.getAttribute("aria-modal")).toBe("true");
+    expect(dialog?.textContent).toContain("Game Saved");
 
     await act(async () => {
-      container.querySelector("button")?.dispatchEvent(
+      dialog?.querySelector('button[type="button"]')?.dispatchEvent(
         new MouseEvent("click", {
           bubbles: true,
         })

--- a/src/game/__tests__/time-pilot.test.ts
+++ b/src/game/__tests__/time-pilot.test.ts
@@ -1,6 +1,33 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { sounds } from "../constants";
 import TimePilot from "../index";
 import userOptions from "../user-options";
+
+const getPlayedSources = (): string[] => {
+  const playedSources: string[] = [];
+
+  Object.defineProperty(HTMLMediaElement.prototype, "canPlay", {
+    configurable: true,
+    value: true,
+  });
+  vi.spyOn(HTMLMediaElement.prototype, "play").mockImplementation(
+    function (this: HTMLMediaElement) {
+      const source = this.querySelector("source")?.getAttribute("src");
+
+      if (source) {
+        playedSources.push(source);
+      }
+
+      return Promise.resolve();
+    }
+  );
+
+  return playedSources;
+};
+
+const waitForAudioTimer = async (): Promise<void> => {
+  await new Promise((resolve) => window.setTimeout(resolve, 5));
+};
 
 describe("TimePilot engine", () => {
   let host: HTMLDivElement;
@@ -28,6 +55,10 @@ describe("TimePilot engine", () => {
     userOptions.setOption("language", "en");
     userOptions.setOption("logLevel", "off");
     userOptions.setOption("uiZoom", 100);
+    Object.defineProperty(HTMLMediaElement.prototype, "canPlay", {
+      configurable: true,
+      value: undefined,
+    });
     Object.defineProperty(navigator, "maxTouchPoints", {
       configurable: true,
       value: 0,
@@ -555,6 +586,63 @@ describe("TimePilot engine", () => {
       },
       version: 1,
     });
+
+    game.destroyGame();
+  });
+
+  it("queues the level intro cue before starting looping level music", async () => {
+    const playedSources = getPlayedSources();
+    const game = new TimePilot(host, { debug: true, gamepadEnabled: false });
+    const pilot = game as unknown as {
+      beginGame: () => void;
+      levelIntroMusic?: { _theSound: HTMLAudioElement };
+    };
+
+    await waitForAudioTimer();
+
+    pilot.beginGame();
+    await waitForAudioTimer();
+
+    expect(playedSources).toContain(sounds.gameStart.src);
+    expect(playedSources).not.toContain(sounds.music.levels[1]?.src);
+
+    HTMLMediaElement.prototype.dispatchEvent.call(
+      pilot.levelIntroMusic?._theSound,
+      new Event("ended")
+    );
+    await waitForAudioTimer();
+
+    expect(playedSources).toContain(sounds.music.levels[1]?.src);
+
+    game.destroyGame();
+  });
+
+  it("resumes paused level music from the menu without replaying the intro cue", async () => {
+    const playedSources = getPlayedSources();
+    const game = new TimePilot(host, { debug: true, gamepadEnabled: false });
+    const pilot = game as unknown as {
+      beginGame: () => void;
+      levelIntroMusic?: { _theSound: HTMLAudioElement };
+      openPauseMenu: () => void;
+    };
+
+    await waitForAudioTimer();
+
+    pilot.beginGame();
+    await waitForAudioTimer();
+    HTMLMediaElement.prototype.dispatchEvent.call(
+      pilot.levelIntroMusic?._theSound,
+      new Event("ended")
+    );
+    await waitForAudioTimer();
+    playedSources.length = 0;
+
+    pilot.openPauseMenu();
+    pilot.beginGame();
+    await waitForAudioTimer();
+
+    expect(playedSources).not.toContain(sounds.gameStart.src);
+    expect(playedSources).toContain(sounds.music.levels[1]?.src);
 
     game.destroyGame();
   });

--- a/src/game/engine/Sound.ts
+++ b/src/game/engine/Sound.ts
@@ -33,6 +33,7 @@ class Sound {
   private readonly _channel: "effects" | "music";
   private readonly _instantDestroy: boolean;
   private readonly _onEnded?: () => void;
+  private _destroyAfterFade = false;
   private _fadeFrame = 0;
   private _fadeMultiplier = 1;
   private _isPlaying = false;
@@ -172,7 +173,11 @@ class Sound {
       return;
     }
 
-    this.fadeTo(0, durationMs, () => this.destroy());
+    this._destroyAfterFade = true;
+    this.fadeTo(0, durationMs, () => {
+      this._destroyAfterFade = false;
+      this.destroy();
+    });
   };
 
   setPan = (pan: number): void => {
@@ -220,12 +225,19 @@ class Sound {
   };
 
   stop = (): void => {
+    const shouldDestroy = this._destroyAfterFade;
+
+    this._destroyAfterFade = false;
     this.cancelFade();
     this._theSound.pause();
     this._isPlaying = false;
     this._playMode = undefined;
     if (this._theSound.currentTime > 0) {
       this._theSound.currentTime = 0;
+    }
+
+    if (shouldDestroy) {
+      this.destroy();
     }
   };
 

--- a/src/game/engine/__tests__/engine.test.ts
+++ b/src/game/engine/__tests__/engine.test.ts
@@ -318,6 +318,31 @@ describe("engine modules", () => {
     sound.destroy();
   });
 
+  it("destroys fade-out sounds when a global stop cancels the fade", () => {
+    Object.defineProperty(HTMLMediaElement.prototype, "canPlay", {
+      configurable: true,
+      value: true,
+    });
+    userOptions.setOption("masterVolume", 10);
+    userOptions.setOption("musicVolume", 5);
+    const sound = new Sound("/music/main_menu.ogg", {
+      autoplay: false,
+      channel: "music",
+      loop: true,
+    });
+    const element = (sound as unknown as { _theSound: HTMLAudioElement })
+      ._theSound;
+
+    sound.loop();
+    expect(element.volume).toBeCloseTo(0.5);
+
+    sound.fadeOutAndDestroy(700);
+    Sound.stopAll();
+    userOptions.setOption("musicVolume", 2);
+
+    expect(element.volume).toBeCloseTo(0.5);
+  });
+
   it("handles browser autoplay rejections without leaking active sound state", async () => {
     Object.defineProperty(HTMLMediaElement.prototype, "canPlay", {
       configurable: true,

--- a/src/game/index.ts
+++ b/src/game/index.ts
@@ -330,6 +330,7 @@ export class TimePilot {
     this.context._renderTicker.stop();
     this.context._renderTicker.clearSchedule();
     this.context._renderTicker.clearTicks();
+    this.spawningSystem.destroy?.();
     this.renderingSystem.destroy?.();
 
     this.context._currentController.forEach((controller: Controller) => {

--- a/src/game/systems/__tests__/systems.test.ts
+++ b/src/game/systems/__tests__/systems.test.ts
@@ -496,6 +496,24 @@ describe("game systems", () => {
     expect(context._bonuses.create).not.toHaveBeenCalled();
   });
 
+  it("plays the wave-start sound when a formation spawns", () => {
+    Object.defineProperty(HTMLMediaElement.prototype, "canPlay", {
+      configurable: true,
+      value: true,
+    });
+    const play = vi.mocked(HTMLMediaElement.prototype.play);
+    const context = createContext();
+    const system = new SpawningSystem(context);
+
+    play.mockClear();
+    vi.spyOn(Math, "random").mockReturnValue(0);
+
+    system.spawnEntities();
+
+    expect(context._enemies.create).toHaveBeenCalledTimes(5);
+    expect(play).toHaveBeenCalledTimes(1);
+  });
+
   it("spawns fast very-slow-homing rockets on level 3", () => {
     const context = createContext({ level: 3 });
     const system = new SpawningSystem(context);

--- a/src/game/systems/spawning.ts
+++ b/src/game/systems/spawning.ts
@@ -1,4 +1,5 @@
-import { levels, limits } from "../constants";
+import { levels, limits, sounds } from "../constants";
+import SoundEngine from "../engine/Sound";
 import helpers from "../engine/helpers";
 import type {
   Coordinates,
@@ -25,6 +26,9 @@ let nextFormationId = 1;
  */
 class SpawningSystem implements SpawningSystemInstance {
   private _context: GameDataStore;
+  private _waveStartSound = new SoundEngine(sounds.waveStart.src, {
+    channel: "effects",
+  });
 
   constructor(context: GameDataStore) {
     this._context = context;
@@ -52,6 +56,10 @@ class SpawningSystem implements SpawningSystemInstance {
           spawnPadding
       );
     }
+  };
+
+  destroy = (): void => {
+    this._waveStartSound.destroy();
   };
 
   spawnEntities = (): void => {
@@ -209,6 +217,8 @@ class SpawningSystem implements SpawningSystemInstance {
       total: formation.slots.length,
     };
     this._context._achievements?.onWaveStarted(formationId);
+    this._waveStartSound.stop();
+    this._waveStartSound.play();
 
     formation.slots.forEach((slot, index) => {
       const position = this._rotateFormationSlot(center, slot, heading);

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -481,6 +481,7 @@ export interface CollisionSystemInstance {
 
 export interface SpawningSystemInstance {
   addInitialProps: () => void;
+  destroy?: () => void;
   spawnEntities: () => void;
 }
 
@@ -764,7 +765,7 @@ export interface TimePilotConstants {
     extraLife: SoundAsset;
     gameStart: SoundAsset;
     music: {
-      levels: Record<number, SoundAsset>;
+      levels: Partial<Record<number, SoundAsset>>;
       menu: SoundAsset;
     };
     nextLevel: SoundAsset;


### PR DESCRIPTION
This pull request introduces several improvements and fixes across the codebase, focusing on accessibility enhancements, service worker updates for a special HTTP header, sound system improvements, and test coverage for new behaviors. The most significant changes are grouped below.

**Service Worker & HTTP Header Enhancements:**

* Added the `X-Clacks-Overhead: GNU Terry Pratchett` HTTP header to all main HTML files and ensured the service worker attaches this header to all cached and served responses, as a tribute and for consistency across navigation and asset requests. (`index.html`, `about/index.html`, `pwa/index.html`, `public/service-worker.js`) [[1]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R11) [[2]](diffhunk://#diff-bfe0fbb110927fa222f1b8585d48110fbe58a164d0146980f5ae793a2d834f89R11) [[3]](diffhunk://#diff-816a23234570a515b50247be49196a9967a940ab44f59141ee2ec54e045c0891R11) [[4]](diffhunk://#diff-c7fe7cbf34906a3e945332fd1e6daf8b29668e3d5f56783bb5232647b48480a7L1-R8) [[5]](diffhunk://#diff-c7fe7cbf34906a3e945332fd1e6daf8b29668e3d5f56783bb5232647b48480a7R24-R38) [[6]](diffhunk://#diff-c7fe7cbf34906a3e945332fd1e6daf8b29668e3d5f56783bb5232647b48480a7R130) [[7]](diffhunk://#diff-c7fe7cbf34906a3e945332fd1e6daf8b29668e3d5f56783bb5232647b48480a7L119-R144) [[8]](diffhunk://#diff-c7fe7cbf34906a3e945332fd1e6daf8b29668e3d5f56783bb5232647b48480a7L135-R155) [[9]](diffhunk://#diff-c7fe7cbf34906a3e945332fd1e6daf8b29668e3d5f56783bb5232647b48480a7L157-R181) [[10]](diffhunk://#diff-c7fe7cbf34906a3e945332fd1e6daf8b29668e3d5f56783bb5232647b48480a7R199-R212) [[11]](diffhunk://#diff-c7fe7cbf34906a3e945332fd1e6daf8b29668e3d5f56783bb5232647b48480a7L195-R224)

* Updated the service worker cache version (to `v6`) and expanded the app shell to include the `/about/` route for offline support. (`public/service-worker.js`)

**Accessibility Improvements:**

* Improved the "exit fallback" modal for app exit scenarios by making it a proper accessible dialog: added `role="dialog"`, `aria-modal="true"`, and focus management for the close button, with corresponding test updates. (`src/components/TimePilotGame.tsx`, `src/components/__tests__/TimePilotGame.test.tsx`) [[1]](diffhunk://#diff-1052c9ab63dc04f6fb9afeff49639c54be7badc9aec053694f6d184943d7798aR82) [[2]](diffhunk://#diff-1052c9ab63dc04f6fb9afeff49639c54be7badc9aec053694f6d184943d7798aR166-R173) [[3]](diffhunk://#diff-1052c9ab63dc04f6fb9afeff49639c54be7badc9aec053694f6d184943d7798aL297-R319) [[4]](diffhunk://#diff-fc39d0b87160c43720c565f64d02c68bcea1d2f140c95c1a817ce38ecc88656bL133-R145)

**Sound System & Audio Behavior:**

* Ensured that the level intro cue (e.g., "game start" sound) is played before looping level music, and that resuming from pause does not replay the intro cue. Added and updated tests to verify these behaviors. (`src/game/index.ts`, `src/game/engine/Sound.ts`, `src/game/__tests__/time-pilot.test.ts`) [[1]](diffhunk://#diff-675a5a2fadca272115e76d87d6d5af7b5545982b940894477b1994bf60d3b1e2R333) [[2]](diffhunk://#diff-df54d6762e7babad12c0dc9d039c3d22c29c0e325a09de70cc958fefe054b656R36) [[3]](diffhunk://#diff-df54d6762e7babad12c0dc9d039c3d22c29c0e325a09de70cc958fefe054b656L175-R180) [[4]](diffhunk://#diff-df54d6762e7babad12c0dc9d039c3d22c29c0e325a09de70cc958fefe054b656R228-R241) [[5]](diffhunk://#diff-648abb83781f7253ea2b07c3a38c83d6861ad06ca726d44cecafc8187e65028aR2-R31) [[6]](diffhunk://#diff-648abb83781f7253ea2b07c3a38c83d6861ad06ca726d44cecafc8187e65028aR58-R61) [[7]](diffhunk://#diff-648abb83781f7253ea2b07c3a38c83d6861ad06ca726d44cecafc8187e65028aR593-R649)

* Fixed a sound system edge case: sounds that are fading out and are stopped globally are now properly destroyed after the fade, preventing leaks. Added a test for this scenario. (`src/game/engine/Sound.ts`, `src/game/engine/__tests__/engine.test.ts`) [[1]](diffhunk://#diff-df54d6762e7babad12c0dc9d039c3d22c29c0e325a09de70cc958fefe054b656R36) [[2]](diffhunk://#diff-df54d6762e7babad12c0dc9d039c3d22c29c0e325a09de70cc958fefe054b656L175-R180) [[3]](diffhunk://#diff-df54d6762e7babad12c0dc9d039c3d22c29c0e325a09de70cc958fefe054b656R228-R241) [[4]](diffhunk://#diff-aa7764634fde402612a41bbdea97c623b21e984d781785db37195b7125305063R321-R345)

**Game System Updates:**

* The enemy spawning system now plays a "wave start" sound when a new formation spawns, and cleans up its sound resource on destruction. Tests were added to verify this behavior. (`src/game/systems/spawning.ts`, `src/game/systems/__tests__/systems.test.ts`) [[1]](diffhunk://#diff-4bddd0ecb47f5cb6c32b0f302a7d2a3a6053ac925fc77212c83796a88ae906e3L1-R2) [[2]](diffhunk://#diff-4bddd0ecb47f5cb6c32b0f302a7d2a3a6053ac925fc77212c83796a88ae906e3R29-R31) [[3]](diffhunk://#diff-4bddd0ecb47f5cb6c32b0f302a7d2a3a6053ac925fc77212c83796a88ae906e3R61-R64) [[4]](diffhunk://#diff-e66ae8bc783124954402a1c301a228061c28908ecc5632c2951e78b7198110b3R499-R516)

**Other:**

* Bumped the application version in `package.json` to `20.2.0`.