### PR TITLE
Remove deprecated fields from manifest: categories, prefer_related_applications, and launch_handler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "time-pilot",
-  "version": "20.7.0",
+  "version": "20.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "time-pilot",
-      "version": "20.7.0",
+      "version": "20.8.0",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "time-pilot",
-  "version": "20.8.0",
+  "version": "20.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "time-pilot",
-      "version": "20.8.0",
+      "version": "20.9.0",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "time-pilot",
-  "version": "20.6.0",
+  "version": "20.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "time-pilot",
-      "version": "20.6.0",
+      "version": "20.7.0",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "time-pilot",
   "private": true,
-  "version": "20.7.0",
+  "version": "20.8.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "time-pilot",
   "private": true,
-  "version": "20.6.0",
+  "version": "20.7.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "time-pilot",
   "private": true,
-  "version": "20.8.0",
+  "version": "20.9.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -11,11 +11,6 @@
   "orientation": "landscape",
   "background_color": "#000000",
   "theme_color": "#000000",
-  "categories": ["games"],
-  "prefer_related_applications": false,
-  "launch_handler": {
-    "client_mode": ["navigate-existing", "auto"]
-  },
   "shortcuts": [
     {
       "name": "Play Time Pilot",

--- a/src/game/__tests__/time-pilot.test.ts
+++ b/src/game/__tests__/time-pilot.test.ts
@@ -549,7 +549,6 @@ describe("TimePilot engine", () => {
       level: 1,
       levelProgress: {
         bossDefeated: false,
-        bossKillThreshold: 56,
         bossSpawned: false,
         standardEnemyKills: 37,
       },
@@ -826,8 +825,7 @@ describe("TimePilot engine", () => {
         level: 3,
         levelProgress: {
           bossDefeated: false,
-          bossKillThreshold: 56,
-          bossSpawned: false,
+          bossSpawned: true,
           standardEnemyKills: 41,
         },
         player: {
@@ -888,6 +886,106 @@ describe("TimePilot engine", () => {
     expect(localStorage.getItem("timePilot.gameSession")).toBeNull();
     expect(pilot.context._gameTicker.isRunning).toBe(true);
     expect(pilot.context._level).toBe(1);
+
+    game.destroyGame();
+  });
+
+  it("clamps out-of-range restored boss progress to the current level threshold", async () => {
+    vi.stubGlobal(
+      "Image",
+      class {
+        complete = true;
+        onerror: (() => void) | null = null;
+        onload: (() => void) | null = null;
+
+        set src(_value: string) {
+          window.setTimeout(() => this.onload?.(), 0);
+        }
+      }
+    );
+    localStorage.setItem(
+      "timePilot.gameSession",
+      JSON.stringify({
+        level: 1,
+        levelProgress: {
+          bossDefeated: false,
+          bossSpawned: true,
+          standardEnemyKills: 999,
+        },
+        player: {
+          continues: 2,
+          heading: 90,
+          lives: 1,
+          nextExtraLifeScore: 50000,
+          posX: 120,
+          posY: -80,
+          score: 34567,
+        },
+        savedAt: Date.now(),
+        version: 1,
+      })
+    );
+    const game = new TimePilot(host, { debug: true });
+    const pilot = game as unknown as {
+      context: {
+        _levelProgress: {
+          bossSpawned: boolean;
+          standardEnemyKills: number;
+        };
+      };
+    };
+
+    await new Promise((resolve) => window.setTimeout(resolve, 5));
+
+    expect(pilot.context._levelProgress.standardEnemyKills).toBe(56);
+    expect(pilot.context._levelProgress.bossSpawned).toBe(false);
+
+    game.destroyGame();
+  });
+
+  it("rejects restored sessions with invalid boss progress types", async () => {
+    vi.stubGlobal(
+      "Image",
+      class {
+        complete = true;
+        onerror: (() => void) | null = null;
+        onload: (() => void) | null = null;
+
+        set src(_value: string) {
+          window.setTimeout(() => this.onload?.(), 0);
+        }
+      }
+    );
+    localStorage.setItem(
+      "timePilot.gameSession",
+      JSON.stringify({
+        level: 1,
+        levelProgress: {
+          bossDefeated: false,
+          bossSpawned: "yes",
+          standardEnemyKills: 12,
+        },
+        player: {
+          continues: 2,
+          heading: 90,
+          lives: 1,
+          nextExtraLifeScore: 50000,
+          posX: 120,
+          posY: -80,
+          score: 34567,
+        },
+        savedAt: Date.now(),
+        version: 1,
+      })
+    );
+    const game = new TimePilot(host, { debug: true });
+    const pilot = game as unknown as {
+      preroll?: unknown;
+    };
+
+    await new Promise((resolve) => window.setTimeout(resolve, 5));
+
+    expect(pilot.preroll).toBeTruthy();
 
     game.destroyGame();
   });

--- a/src/game/__tests__/time-pilot.test.ts
+++ b/src/game/__tests__/time-pilot.test.ts
@@ -518,6 +518,12 @@ describe("TimePilot engine", () => {
     const pilot = game as unknown as {
       beginGame: () => void;
       context: {
+        _levelProgress: {
+          bossDefeated: boolean;
+          bossKillThreshold: number;
+          bossSpawned: boolean;
+          standardEnemyKills: number;
+        };
         _player: {
           setData: (key: string, value: unknown, isLastKnownGood?: boolean) => void;
         };
@@ -532,6 +538,7 @@ describe("TimePilot engine", () => {
     pilot.context._player.setData("continues", 1, true);
     pilot.context._player.setData("posX", 42);
     pilot.context._player.setData("posY", -24);
+    pilot.context._levelProgress.standardEnemyKills = 37;
     window.dispatchEvent(new Event("pagehide"));
 
     const snapshot = JSON.parse(
@@ -540,6 +547,12 @@ describe("TimePilot engine", () => {
 
     expect(snapshot).toMatchObject({
       level: 1,
+      levelProgress: {
+        bossDefeated: false,
+        bossKillThreshold: 56,
+        bossSpawned: false,
+        standardEnemyKills: 37,
+      },
       player: {
         continues: 1,
         lives: 2,
@@ -811,6 +824,12 @@ describe("TimePilot engine", () => {
       "timePilot.gameSession",
       JSON.stringify({
         level: 3,
+        levelProgress: {
+          bossDefeated: false,
+          bossKillThreshold: 56,
+          bossSpawned: false,
+          standardEnemyKills: 41,
+        },
         player: {
           continues: 2,
           heading: 90,
@@ -829,6 +848,12 @@ describe("TimePilot engine", () => {
       context: {
         _gameTicker: { isRunning: boolean };
         _level: number;
+        _levelProgress: {
+          bossDefeated: boolean;
+          bossKillThreshold: number;
+          bossSpawned: boolean;
+          standardEnemyKills: number;
+        };
         _menus: { next: () => void; activate: () => void; render: () => void };
         _player: {
           getData: (
@@ -851,6 +876,10 @@ describe("TimePilot engine", () => {
     expect(pilot.context._player.getData("heading")).toBe(90);
     expect(pilot.context._player.getData("posX")).toBe(120);
     expect(pilot.context._player.getData("posY")).toBe(-80);
+    expect(pilot.context._levelProgress.standardEnemyKills).toBe(41);
+    expect(pilot.context._levelProgress.bossKillThreshold).toBe(56);
+    expect(pilot.context._levelProgress.bossSpawned).toBe(false);
+    expect(pilot.context._levelProgress.bossDefeated).toBe(false);
     expect(renderText).toHaveBeenCalled();
 
     pilot.context._menus.next();

--- a/src/game/index.ts
+++ b/src/game/index.ts
@@ -109,10 +109,7 @@ type GameSessionSnapshot = {
   level: number;
   levelProgress?: Pick<
     LevelProgressState,
-    | "bossDefeated"
-    | "bossKillThreshold"
-    | "bossSpawned"
-    | "standardEnemyKills"
+    "bossDefeated" | "bossSpawned" | "standardEnemyKills"
   >;
   player: Pick<
     PlayerData,
@@ -897,7 +894,6 @@ export class TimePilot {
       const hasInvalidLevelProgress =
         !!snapshot?.levelProgress &&
         (typeof snapshot.levelProgress.bossDefeated !== "boolean" ||
-          typeof snapshot.levelProgress.bossKillThreshold !== "number" ||
           typeof snapshot.levelProgress.bossSpawned !== "boolean" ||
           typeof snapshot.levelProgress.standardEnemyKills !== "number");
 
@@ -964,7 +960,6 @@ export class TimePilot {
       level: this.context._level,
       levelProgress: {
         bossDefeated: levelProgress.bossDefeated,
-        bossKillThreshold: levelProgress.bossKillThreshold,
         bossSpawned: levelProgress.bossSpawned,
         standardEnemyKills: levelProgress.standardEnemyKills,
       },
@@ -1032,16 +1027,18 @@ export class TimePilot {
     this.selectedStartLevel = snapshot.level;
     this.resetWorld(snapshot.level, { skipIntro: true });
     if (snapshot.levelProgress) {
+      const currentThreshold = this.context._levelProgress.bossKillThreshold;
+      const bossWasDefeated = snapshot.levelProgress.bossDefeated;
+
       this.context._levelProgress = {
         ...this.context._levelProgress,
-        bossDefeated: snapshot.levelProgress.bossDefeated,
-        bossKillThreshold: Math.max(1, snapshot.levelProgress.bossKillThreshold),
-        bossSpawned: snapshot.levelProgress.bossSpawned,
+        bossDefeated: bossWasDefeated,
+        bossSpawned: bossWasDefeated && snapshot.levelProgress.bossSpawned,
         standardEnemyKills: Math.max(
           0,
           Math.min(
             snapshot.levelProgress.standardEnemyKills,
-            Math.max(1, snapshot.levelProgress.bossKillThreshold)
+            currentThreshold
           )
         ),
       };

--- a/src/game/index.ts
+++ b/src/game/index.ts
@@ -42,6 +42,7 @@ import type {
   EnemyData,
   EnemyInstance,
   GameDataStore,
+  LevelProgressState,
   PlayerData,
   RenderingSystemInstance,
   SpawningSystemInstance,
@@ -106,6 +107,13 @@ type DemoProgressSnapshot = {
 
 type GameSessionSnapshot = {
   level: number;
+  levelProgress?: Pick<
+    LevelProgressState,
+    | "bossDefeated"
+    | "bossKillThreshold"
+    | "bossSpawned"
+    | "standardEnemyKills"
+  >;
   player: Pick<
     PlayerData,
     | "continues"
@@ -886,6 +894,12 @@ export class TimePilot {
       const snapshot = JSON.parse(
         storage.getItem(gameSessionStorageKey) ?? "null"
       ) as Partial<GameSessionSnapshot> | null;
+      const hasInvalidLevelProgress =
+        !!snapshot?.levelProgress &&
+        (typeof snapshot.levelProgress.bossDefeated !== "boolean" ||
+          typeof snapshot.levelProgress.bossKillThreshold !== "number" ||
+          typeof snapshot.levelProgress.bossSpawned !== "boolean" ||
+          typeof snapshot.levelProgress.standardEnemyKills !== "number");
 
       if (
         !snapshot ||
@@ -899,7 +913,8 @@ export class TimePilot {
         typeof snapshot.player.nextExtraLifeScore !== "number" ||
         typeof snapshot.player.posX !== "number" ||
         typeof snapshot.player.posY !== "number" ||
-        typeof snapshot.player.heading !== "number"
+        typeof snapshot.player.heading !== "number" ||
+        hasInvalidLevelProgress
       ) {
         return null;
       }
@@ -944,8 +959,15 @@ export class TimePilot {
     }
 
     const playerData = this.context._player.getData();
+    const levelProgress = this.context._levelProgress;
     const snapshot: GameSessionSnapshot = {
       level: this.context._level,
+      levelProgress: {
+        bossDefeated: levelProgress.bossDefeated,
+        bossKillThreshold: levelProgress.bossKillThreshold,
+        bossSpawned: levelProgress.bossSpawned,
+        standardEnemyKills: levelProgress.standardEnemyKills,
+      },
       player: {
         continues: playerData.continues,
         heading: playerData.heading,
@@ -1009,6 +1031,21 @@ export class TimePilot {
     this.hasShownGameOver = false;
     this.selectedStartLevel = snapshot.level;
     this.resetWorld(snapshot.level, { skipIntro: true });
+    if (snapshot.levelProgress) {
+      this.context._levelProgress = {
+        ...this.context._levelProgress,
+        bossDefeated: snapshot.levelProgress.bossDefeated,
+        bossKillThreshold: Math.max(1, snapshot.levelProgress.bossKillThreshold),
+        bossSpawned: snapshot.levelProgress.bossSpawned,
+        standardEnemyKills: Math.max(
+          0,
+          Math.min(
+            snapshot.levelProgress.standardEnemyKills,
+            Math.max(1, snapshot.levelProgress.bossKillThreshold)
+          )
+        ),
+      };
+    }
     this.context._player.setData("score", snapshot.player.score, true);
     this.context._player.setData("lives", snapshot.player.lives, true);
     this.context._player.setData("continues", snapshot.player.continues, true);


### PR DESCRIPTION
This pull request enhances the game session save and restore functionality in Time Pilot by adding support for persisting and validating level progress state, including boss and enemy kill information. It also introduces robust validation and clamping logic to prevent corrupted or out-of-range progress data from being restored, improving reliability when resuming games.

**Game session persistence and validation improvements:**

* Added `levelProgress` to the session snapshot, persisting boss state (`bossDefeated`, `bossSpawned`) and `standardEnemyKills` when saving or restoring a game (`src/game/index.ts`). [[1]](diffhunk://#diff-675a5a2fadca272115e76d87d6d5af7b5545982b940894477b1994bf60d3b1e2R110-R113) [[2]](diffhunk://#diff-675a5a2fadca272115e76d87d6d5af7b5545982b940894477b1994bf60d3b1e2R958-R965)
* Implemented validation to reject restored sessions with invalid `levelProgress` types, preventing corrupted game state (`src/game/index.ts`). [[1]](diffhunk://#diff-675a5a2fadca272115e76d87d6d5af7b5545982b940894477b1994bf60d3b1e2R894-R898) [[2]](diffhunk://#diff-675a5a2fadca272115e76d87d6d5af7b5545982b940894477b1994bf60d3b1e2L902-R913)
* Added logic to clamp out-of-range `standardEnemyKills` values to the current level's boss kill threshold when restoring progress, ensuring consistent gameplay (`src/game/index.ts`).

**Test coverage:**

* Expanded test suite to verify correct persistence and restoration of `levelProgress`, including new tests for clamping and type validation of boss progress (`src/game/__tests__/time-pilot.test.ts`). [[1]](diffhunk://#diff-648abb83781f7253ea2b07c3a38c83d6861ad06ca726d44cecafc8187e65028aR826-R830) [[2]](diffhunk://#diff-648abb83781f7253ea2b07c3a38c83d6861ad06ca726d44cecafc8187e65028aR893-R992)

**Other changes:**

* Bumped package version to `20.9.0` in `package.json` to reflect new features.
* Cleaned up unused or unnecessary manifest fields in `public/manifest.webmanifest`.