### PR TITLE
Feature/highscores 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,13 +80,17 @@ npm run api
 During local development, Vite proxies `/api/*` to
 `http://localhost:8787` by default. Set `HIGH_SCORE_API_URL` before
 `npm run dev` if the API is running somewhere else.
+Set `VITE_API_MODE=offline` when building a static/local-only release that
+should not try to contact backend APIs.
 
 ## 🏅 High Score Storage
 
 High scores are local-first. The game immediately saves submitted scores to
 `localStorage`, so score entry works offline and without any backend. When the
 high-score API is reachable, scores from online player runs are synced to the
-remote table and merged back into the local leaderboard.
+remote table and merged back into the local leaderboard. If the API is absent,
+blocked, or offline, the game falls back to local scores, shows the offline sync
+indicator, and periodically probes for the API to return.
 
 The API uses PostgreSQL when `DATABASE_URL` is configured:
 

--- a/README.md
+++ b/README.md
@@ -110,8 +110,11 @@ Remote score submission is best-effort secure. The client asks the API for a
 single-use signed run receipt at the start of an online run, then includes that
 receipt when a score is submitted. The server checks the receipt, expiry,
 single-use status, score shape, and basic score/stat plausibility before storing
-the score. Offline runs still save locally, but they do not receive a remote run
-receipt and are treated as local-only rather than trusted remote submissions.
+the score. Pending local submissions also carry a lightweight integrity envelope
+so casual local-storage edits are downgraded to local-only before sync, and the
+API rejects submissions whose envelope no longer matches the score payload.
+Offline runs still save locally, but they do not receive a remote run receipt and
+are treated as local-only rather than trusted remote submissions.
 See [PRIVACY.md](PRIVACY.md) for the backend data-storage breakdown.
 
 ## 📱 Installable PWA

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "time-pilot",
-  "version": "22.0.0",
+  "version": "22.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "time-pilot",
-      "version": "22.0.0",
+      "version": "22.1.0",
       "dependencies": {
         "pg": "^8.21.0",
         "react": "^18.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "time-pilot",
-  "version": "21.20.0",
+  "version": "22.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "time-pilot",
-      "version": "21.20.0",
+      "version": "22.0.0",
       "dependencies": {
         "pg": "^8.21.0",
         "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "time-pilot",
   "private": true,
-  "version": "21.20.0",
+  "version": "22.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "time-pilot",
   "private": true,
-  "version": "22.0.0",
+  "version": "22.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server/high-score-server.mjs
+++ b/server/high-score-server.mjs
@@ -13,6 +13,10 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const jsonStorePath = resolve(__dirname, "../data/high-scores.json");
 const maxBodyBytes = 64 * 1024;
 const maxGameEra = 5;
+const highScoreIntegrityVersion = 1;
+const highScoreIntegrityHashModulo = 1000003;
+const highScoreIntegrityMinMultiplier = 101;
+const highScoreIntegrityMultiplierRange = 897;
 const maxPlausibleAccuracy = 100;
 const maxPlausibleBonuses = 200;
 const maxPlausibleBosses = 5;
@@ -340,7 +344,7 @@ const validateScoreSubmission = async (payload) => {
     return reject("invalid_payload");
   }
 
-  const { entry, gameVersion, run, submittedAt } = payload;
+  const { entry, gameVersion, integrity, run, submittedAt } = payload;
 
   if (!isPublicScore(entry) || typeof submittedAt !== "number") {
     return reject("invalid_score");
@@ -348,6 +352,10 @@ const validateScoreSubmission = async (payload) => {
 
   if (!isRunReceipt(run)) {
     return reject("missing_run_receipt", 401);
+  }
+
+  if (!isValidHighScoreIntegrity(entry, integrity, run, submittedAt)) {
+    return reject("invalid_score_integrity", 422);
   }
 
   if (!isPlausibleScore(entry)) {
@@ -427,6 +435,85 @@ const clampNumber = (value, min, max) => {
   }
 
   return Math.max(min, Math.min(max, value));
+};
+
+const isValidHighScoreIntegrity = (entry, integrity, run, submittedAt) => {
+  if (!isHighScoreIntegrity(integrity)) {
+    return false;
+  }
+
+  const expectedScoreProduct =
+    Math.max(0, Math.floor(entry.score)) * integrity.multiplier;
+  const expectedStatsProduct =
+    (hashText(entry.stats.join("\n")) % highScoreIntegrityHashModulo) *
+    integrity.multiplier;
+
+  return (
+    integrity.scoreProduct === expectedScoreProduct &&
+    integrity.statsProduct === expectedStatsProduct &&
+    integrity.checksum ===
+      createHighScoreIntegrityChecksum(
+        entry,
+        run,
+        submittedAt,
+        integrity.multiplier,
+        integrity.scoreProduct,
+        integrity.statsProduct
+      )
+  );
+};
+
+const isHighScoreIntegrity = (value) => {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  return (
+    value.version === highScoreIntegrityVersion &&
+    Number.isInteger(value.multiplier) &&
+    value.multiplier >= highScoreIntegrityMinMultiplier &&
+    value.multiplier <
+      highScoreIntegrityMinMultiplier + highScoreIntegrityMultiplierRange &&
+    Number.isInteger(value.scoreProduct) &&
+    Number.isInteger(value.statsProduct) &&
+    typeof value.checksum === "string"
+  );
+};
+
+const createHighScoreIntegrityChecksum = (
+  entry,
+  run,
+  submittedAt,
+  multiplier,
+  scoreProduct,
+  statsProduct
+) =>
+  hashText(
+    [
+      highScoreIntegrityVersion,
+      run.runId,
+      run.token,
+      run.issuedAt,
+      entry.id,
+      entry.name,
+      Math.max(0, Math.floor(entry.score)),
+      entry.stats.join("\n"),
+      submittedAt,
+      multiplier,
+      scoreProduct,
+      statsProduct,
+    ].join("|")
+  ).toString(36);
+
+const hashText = (text) => {
+  let hash = 2166136261;
+
+  for (let index = 0; index < text.length; index += 1) {
+    hash ^= text.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+
+  return hash >>> 0;
 };
 
 export const __testHooks = {

--- a/server/high-score-server.mjs
+++ b/server/high-score-server.mjs
@@ -313,7 +313,7 @@ const handleSubmitScore = async (request, response) => {
   const receivedAt = Date.now();
   const scoreRecord = {
     ...validation.score,
-    createdAt: validation.createdAt,
+    createdAt: receivedAt,
     gameVersion: validation.gameVersion,
     receivedAt,
     runId: validation.run.runId,
@@ -367,7 +367,6 @@ const validateScoreSubmission = async (payload) => {
       score: Math.max(0, Math.floor(entry.score)),
       stats: entry.stats.slice(0, maxScoreStats),
     },
-    createdAt: Math.max(0, Math.floor(entry.createdAt ?? submittedAt)),
     submittedAt: Math.max(0, Math.floor(submittedAt)),
   };
 };

--- a/src/game/__tests__/high-scores.test.ts
+++ b/src/game/__tests__/high-scores.test.ts
@@ -333,6 +333,53 @@ describe("high score storage", () => {
     );
   });
 
+  it("does not submit pending scores with invalid local integrity", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(createJsonResponse([]));
+
+    localStorage.setItem(
+      highScoreStorageKey,
+      JSON.stringify([
+        {
+          id: "tampered-score",
+          createdAt: 2000,
+          integrity: {
+            checksum: "bad",
+            multiplier: 101,
+            scoreProduct: 1,
+            statsProduct: 1,
+            version: 1,
+          },
+          name: "Tampered",
+          run: {
+            issuedAt: 1000,
+            runId: "run-tampered",
+            token: "receipt-token",
+          },
+          score: 999999,
+          stats: ["Era: 1910"],
+          submittedAt: 2000,
+          syncState: "pending",
+        },
+      ])
+    );
+
+    await syncHighScores();
+
+    const storedScores = JSON.parse(
+      localStorage.getItem(highScoreStorageKey) ?? "[]"
+    ) as Array<{ integrity?: unknown; run?: unknown; syncState: string }>;
+
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      "/api/high-scores",
+      expect.objectContaining({ method: "POST" })
+    );
+    expect(storedScores[0]).toMatchObject({ syncState: "local" });
+    expect(storedScores[0]?.integrity).toBeUndefined();
+    expect(storedScores[0]?.run).toBeUndefined();
+  });
+
   it("persists successful pending sync updates before a later submit fails", async () => {
     const remoteEntry = {
       id: "remote-score",

--- a/src/game/__tests__/high-scores.test.ts
+++ b/src/game/__tests__/high-scores.test.ts
@@ -26,6 +26,8 @@ describe("high score storage", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
   });
 
   it("keeps scores local-only when no remote run receipt exists", async () => {
@@ -177,6 +179,35 @@ describe("high score storage", () => {
     expect(getHighScores()).toHaveLength(10);
   });
 
+  it("skips remote sync when API access is configured offline", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(createJsonResponse([]));
+    vi.stubEnv("VITE_API_MODE", "offline");
+
+    await syncHighScores();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(getHighScoreSyncStatus()).toBe("error");
+  });
+
+  it("stores receipt-backed scores locally when API access is configured offline", () => {
+    vi.stubEnv("VITE_API_MODE", "offline");
+
+    saveHighScore("Static Pilot", 5000, ["Era: 1910"], {
+      issuedAt: 1000,
+      runId: "run-static",
+      token: "receipt-token",
+    });
+
+    const storedScores = JSON.parse(
+      localStorage.getItem(highScoreStorageKey) ?? "[]"
+    ) as Array<{ run?: unknown; syncState: string }>;
+
+    expect(storedScores[0]).toMatchObject({ syncState: "local" });
+    expect(storedScores[0]?.run).toBeUndefined();
+  });
+
   it("downgrades terminal sync rejections to local scores", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation((input, init) => {
       if (input === "/api/high-scores" && init?.method === "POST") {
@@ -218,6 +249,88 @@ describe("high score storage", () => {
     expect(storedScores[0]).toMatchObject({ syncState: "local" });
     expect(storedScores[0]?.run).toBeUndefined();
     expect(getHighScoreSyncStatus()).toBe("success");
+  });
+
+  it("caches remote high-score tables without resubmitting cached rows", async () => {
+    const remoteEntry = {
+      id: "remote-cached-score",
+      createdAt: 2000,
+      name: "Remote Pilot",
+      receivedAt: 3000,
+      score: 8000,
+      stats: ["Era: 1910"],
+    };
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(createJsonResponse([remoteEntry]));
+
+    await syncHighScores();
+    await syncHighScores();
+
+    const storedScores = JSON.parse(
+      localStorage.getItem(highScoreStorageKey) ?? "[]"
+    ) as Array<{ id: string; syncState: string }>;
+
+    expect(storedScores[0]).toMatchObject({
+      id: "remote-cached-score",
+      syncState: "synced",
+    });
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      "/api/high-scores",
+      expect.objectContaining({ method: "POST" })
+    );
+  });
+
+  it("keeps pending local submissions when caching a full remote table", async () => {
+    const remoteScores = Array.from({ length: 60 }, (_, index) => ({
+      id: `remote-score-${index}`,
+      createdAt: 1000 + index,
+      name: `Remote ${index}`,
+      receivedAt: 2000 + index,
+      score: 100000 - index,
+      stats: ["Era: 1910"],
+    }));
+
+    vi.spyOn(globalThis, "fetch").mockImplementation((input, init) => {
+      if (input === "/api/high-scores" && init?.method === "POST") {
+        return Promise.reject(new Error("offline"));
+      }
+
+      return Promise.resolve(createJsonResponse(remoteScores));
+    });
+
+    localStorage.setItem(
+      highScoreStorageKey,
+      JSON.stringify([
+        {
+          id: "low-pending-score",
+          createdAt: 5000,
+          name: "Pending Pilot",
+          run: {
+            issuedAt: 1000,
+            runId: "run-pending",
+            token: "receipt-token",
+          },
+          score: 1,
+          stats: ["Era: 1910"],
+          submittedAt: 5000,
+          syncState: "pending",
+        },
+      ])
+    );
+
+    await syncHighScores();
+
+    const storedScores = JSON.parse(
+      localStorage.getItem(highScoreStorageKey) ?? "[]"
+    ) as Array<{ id: string; syncState: string }>;
+
+    expect(storedScores).toContainEqual(
+      expect.objectContaining({
+        id: "low-pending-score",
+        syncState: "pending",
+      })
+    );
   });
 
   it("persists successful pending sync updates before a later submit fails", async () => {

--- a/src/game/high-scores.ts
+++ b/src/game/high-scores.ts
@@ -9,10 +9,19 @@ interface HighScoreRunReceipt {
 }
 
 interface StoredHighScoreEntry extends HighScoreEntry {
+  integrity?: HighScoreIntegrity;
   receivedAt?: number;
   run?: HighScoreRunReceipt;
   submittedAt: number;
   syncState: HighScoreSyncState;
+}
+
+interface HighScoreIntegrity {
+  checksum: string;
+  multiplier: number;
+  scoreProduct: number;
+  statsProduct: number;
+  version: 1;
 }
 
 const highScoreStorageKey = "timePilot.highScores";
@@ -20,6 +29,10 @@ const highScoreApiBasePath = "/api/high-scores";
 const highScoreApiTimeoutMs = 2500;
 const highScoreApiProbeIntervalMs = 30000;
 const fakeHighScoreBaseCreatedAt = Date.UTC(2012, 8, 13);
+const highScoreIntegrityVersion = 1;
+const highScoreIntegrityHashModulo = 1000003;
+const highScoreIntegrityMinMultiplier = 101;
+const highScoreIntegrityMultiplierRange = 897;
 const maxHighScoreStats = 12;
 const maxStoredHighScores = 10;
 const maxCachedHighScores = 50;
@@ -239,6 +252,11 @@ export const saveHighScore = (
     submittedAt: createdAt,
     syncState: shouldSync ? "pending" : "local",
   };
+
+  if (shouldSync && entry.run) {
+    entry.integrity = createHighScoreIntegrity(entry, entry.run);
+  }
+
   const storedScores = trimStoredScoreRecords(
     upsertScoreRecords(loadStoredScoreRecords(), [entry])
   );
@@ -346,6 +364,17 @@ const submitPendingScores = async (): Promise<boolean> => {
       continue;
     }
 
+    if (!record.integrity) {
+      record.integrity = createHighScoreIntegrity(record, record.run);
+      changed = true;
+    } else if (!isValidHighScoreIntegrity(record, record.run)) {
+      record.integrity = undefined;
+      record.run = undefined;
+      record.syncState = "local";
+      changed = true;
+      continue;
+    }
+
     try {
       const response = await fetchHighScoreApi("", {
         method: "POST",
@@ -355,6 +384,7 @@ const submitPendingScores = async (): Promise<boolean> => {
         body: JSON.stringify({
           entry: toHighScoreEntry(record),
           gameVersion: getGameVersion(),
+          integrity: record.integrity,
           run: record.run,
           submittedAt: record.submittedAt,
         }),
@@ -366,6 +396,7 @@ const submitPendingScores = async (): Promise<boolean> => {
       }
 
       if (isTerminalSyncRejection(response.status)) {
+        record.integrity = undefined;
         record.syncState = "local";
         record.run = undefined;
         changed = true;
@@ -391,7 +422,9 @@ const submitPendingScores = async (): Promise<boolean> => {
       record.name = storedRemoteEntry.name;
       record.score = Math.max(0, Math.floor(storedRemoteEntry.score));
       record.stats = storedRemoteEntry.stats.slice(0, maxHighScoreStats);
+      record.integrity = undefined;
       record.receivedAt = storedRemoteEntry.receivedAt ?? Date.now();
+      record.run = undefined;
       record.syncState = "synced";
       changed = true;
     } catch {
@@ -505,6 +538,9 @@ const normalizeStoredEntry = (
     run: isHighScoreRunReceipt(stored.run) ? stored.run : undefined,
     score: Math.max(0, Math.floor(entry.score)),
     stats: entry.stats.slice(0, maxHighScoreStats),
+    integrity: isHighScoreIntegrity(stored.integrity)
+      ? stored.integrity
+      : undefined,
     submittedAt:
       typeof stored.submittedAt === "number" ? stored.submittedAt : Date.now(),
     syncState: normalizeSyncState(stored.syncState, stored.run),
@@ -528,6 +564,96 @@ const normalizeSyncState = (
 
 const isTerminalSyncRejection = (status: number): boolean =>
   status === 401 || status === 422;
+
+const createHighScoreIntegrity = (
+  entry: HighScoreEntry & Pick<StoredHighScoreEntry, "submittedAt">,
+  run: HighScoreRunReceipt
+): HighScoreIntegrity => {
+  const multiplier =
+    highScoreIntegrityMinMultiplier +
+    Math.floor(Math.random() * highScoreIntegrityMultiplierRange);
+  const scoreProduct = Math.max(0, Math.floor(entry.score)) * multiplier;
+  const statsProduct =
+    (hashText(entry.stats.join("\n")) % highScoreIntegrityHashModulo) *
+    multiplier;
+
+  return {
+    checksum: createHighScoreIntegrityChecksum(
+      entry,
+      run,
+      multiplier,
+      scoreProduct,
+      statsProduct
+    ),
+    multiplier,
+    scoreProduct,
+    statsProduct,
+    version: highScoreIntegrityVersion,
+  };
+};
+
+const isValidHighScoreIntegrity = (
+  entry: HighScoreEntry & Pick<StoredHighScoreEntry, "integrity" | "submittedAt">,
+  run: HighScoreRunReceipt
+): boolean => {
+  if (!isHighScoreIntegrity(entry.integrity)) {
+    return false;
+  }
+
+  const expectedScoreProduct =
+    Math.max(0, Math.floor(entry.score)) * entry.integrity.multiplier;
+  const expectedStatsProduct =
+    (hashText(entry.stats.join("\n")) % highScoreIntegrityHashModulo) *
+    entry.integrity.multiplier;
+
+  return (
+    entry.integrity.scoreProduct === expectedScoreProduct &&
+    entry.integrity.statsProduct === expectedStatsProduct &&
+    entry.integrity.checksum ===
+      createHighScoreIntegrityChecksum(
+        entry,
+        run,
+        entry.integrity.multiplier,
+        entry.integrity.scoreProduct,
+        entry.integrity.statsProduct
+      )
+  );
+};
+
+const createHighScoreIntegrityChecksum = (
+  entry: HighScoreEntry & Pick<StoredHighScoreEntry, "submittedAt">,
+  run: HighScoreRunReceipt,
+  multiplier: number,
+  scoreProduct: number,
+  statsProduct: number
+): string =>
+  hashText(
+    [
+      highScoreIntegrityVersion,
+      run.runId,
+      run.token,
+      run.issuedAt,
+      entry.id,
+      entry.name,
+      Math.max(0, Math.floor(entry.score)),
+      entry.stats.join("\n"),
+      entry.submittedAt,
+      multiplier,
+      scoreProduct,
+      statsProduct,
+    ].join("|")
+  ).toString(36);
+
+const hashText = (text: string): number => {
+  let hash = 2166136261;
+
+  for (let index = 0; index < text.length; index += 1) {
+    hash ^= text.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+
+  return hash >>> 0;
+};
 
 const markHighScoreApiOffline = (): void => {
   highScoreApiOffline = true;
@@ -610,6 +736,28 @@ const isHighScoreRunReceipt = (
     typeof receipt.issuedAt === "number" &&
     typeof receipt.runId === "string" &&
     typeof receipt.token === "string"
+  );
+};
+
+const isHighScoreIntegrity = (value: unknown): value is HighScoreIntegrity => {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const integrity = value as Partial<HighScoreIntegrity>;
+
+  return (
+    integrity.version === highScoreIntegrityVersion &&
+    typeof integrity.multiplier === "number" &&
+    Number.isInteger(integrity.multiplier) &&
+    integrity.multiplier >= highScoreIntegrityMinMultiplier &&
+    integrity.multiplier <
+      highScoreIntegrityMinMultiplier + highScoreIntegrityMultiplierRange &&
+    typeof integrity.scoreProduct === "number" &&
+    Number.isInteger(integrity.scoreProduct) &&
+    typeof integrity.statsProduct === "number" &&
+    Number.isInteger(integrity.statsProduct) &&
+    typeof integrity.checksum === "string"
   );
 };
 

--- a/src/game/high-scores.ts
+++ b/src/game/high-scores.ts
@@ -17,17 +17,47 @@ interface StoredHighScoreEntry extends HighScoreEntry {
 
 const highScoreStorageKey = "timePilot.highScores";
 const highScoreApiBasePath = "/api/high-scores";
+const highScoreApiTimeoutMs = 2500;
+const highScoreApiProbeIntervalMs = 30000;
 const fakeHighScoreBaseCreatedAt = Date.UTC(2012, 8, 13);
 const maxHighScoreStats = 12;
 const maxStoredHighScores = 10;
 const maxCachedHighScores = 50;
+let highScoreApiOffline = false;
+let highScoreApiProbeInFlight = false;
+let highScoreApiLastProbeAt = 0;
 let highScoreSyncStatus: HighScoreSyncStatus | null = "waiting";
 
 /**
  * Returns the latest high-score save/sync status for menu indicators.
  */
-export const getHighScoreSyncStatus = (): HighScoreSyncStatus | null =>
-  highScoreSyncStatus;
+export const getHighScoreSyncStatus = (): HighScoreSyncStatus | null => {
+  queueHighScoreApiProbe();
+  return highScoreSyncStatus;
+};
+
+const queueHighScoreApiProbe = (): void => {
+  if (
+    highScoreSyncStatus !== "error" ||
+    !highScoreApiOffline ||
+    highScoreApiProbeInFlight ||
+    isApiDisabledByConfig()
+  ) {
+    return;
+  }
+
+  const now = Date.now();
+
+  if (now - highScoreApiLastProbeAt < highScoreApiProbeIntervalMs) {
+    return;
+  }
+
+  highScoreApiLastProbeAt = now;
+  highScoreApiProbeInFlight = true;
+  void syncHighScores().finally(() => {
+    highScoreApiProbeInFlight = false;
+  });
+};
 
 const setHighScoreSyncStatus = (status: HighScoreSyncStatus | null): void => {
   highScoreSyncStatus = status;
@@ -143,10 +173,15 @@ export const getHighScoreThresholds = (limit: number): HighScoreEntry[] =>
  * Starts a remotely verifiable high-score run when the API is available.
  */
 export const startHighScoreRun = async (): Promise<HighScoreRunReceipt | null> => {
+  if (!canUseHighScoreApi()) {
+    setHighScoreSyncStatus("error");
+    return null;
+  }
+
   setHighScoreSyncStatus("syncing");
 
   try {
-    const response = await fetch(`${highScoreApiBasePath}/runs`, {
+    const response = await fetchHighScoreApi("/runs", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -157,7 +192,8 @@ export const startHighScoreRun = async (): Promise<HighScoreRunReceipt | null> =
       }),
     });
 
-    if (!response.ok) {
+    if (!response?.ok) {
+      markHighScoreApiOffline();
       setHighScoreSyncStatus("error");
       return null;
     }
@@ -165,13 +201,16 @@ export const startHighScoreRun = async (): Promise<HighScoreRunReceipt | null> =
     const receipt = (await response.json()) as Partial<HighScoreRunReceipt>;
 
     if (!isHighScoreRunReceipt(receipt)) {
+      markHighScoreApiOffline();
       setHighScoreSyncStatus("error");
       return null;
     }
 
+    highScoreApiOffline = false;
     setHighScoreSyncStatus("success");
     return receipt;
   } catch {
+    markHighScoreApiOffline();
     setHighScoreSyncStatus("error");
     return null;
   }
@@ -186,21 +225,23 @@ export const saveHighScore = (
   stats: string[],
   run?: HighScoreRunReceipt | null
 ): HighScoreEntry => {
-  setHighScoreSyncStatus(run ? "syncing" : "waiting");
+  const shouldSync = Boolean(run && canUseHighScoreApi());
+
+  setHighScoreSyncStatus(shouldSync ? "syncing" : "waiting");
   const createdAt = Date.now();
   const entry: StoredHighScoreEntry = {
     createdAt,
     id: `local-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
     name: normalizeHighScoreName(name),
-    run: run ?? undefined,
+    run: shouldSync ? run ?? undefined : undefined,
     score: Math.max(0, Math.floor(score)),
     stats: stats.slice(0, maxHighScoreStats),
     submittedAt: createdAt,
-    syncState: run ? "pending" : "local",
+    syncState: shouldSync ? "pending" : "local",
   };
-  const storedScores = upsertScoreRecords(loadStoredScoreRecords(), [entry])
-    .sort(sortHighScores)
-    .slice(0, maxCachedHighScores);
+  const storedScores = trimStoredScoreRecords(
+    upsertScoreRecords(loadStoredScoreRecords(), [entry])
+  );
 
   saveStoredScoreRecords(storedScores);
   void syncHighScores();
@@ -212,13 +253,23 @@ export const saveHighScore = (
  * Best-effort two-way sync between local high scores and the remote API.
  */
 export const syncHighScores = async (): Promise<void> => {
+  if (!canUseHighScoreApi()) {
+    markHighScoreApiOffline();
+    setHighScoreSyncStatus("error");
+    return;
+  }
+
   setHighScoreSyncStatus("syncing");
   const submitted = await submitPendingScores();
   const pulled = await pullRemoteScores();
+  const synced = submitted && pulled && !hasPendingScores();
 
-  setHighScoreSyncStatus(
-    submitted && pulled && !hasPendingScores() ? "success" : "error"
-  );
+  if (synced) {
+    highScoreApiOffline = false;
+  } else {
+    markHighScoreApiOffline();
+  }
+  setHighScoreSyncStatus(synced ? "success" : "error");
 };
 
 /**
@@ -268,7 +319,7 @@ const saveStoredScoreRecords = (entries: StoredHighScoreEntry[]): void => {
   try {
     getStorage()?.setItem(
       highScoreStorageKey,
-      JSON.stringify(entries.sort(sortHighScores).slice(0, maxCachedHighScores))
+      JSON.stringify(trimStoredScoreRecords(entries))
     );
   } catch {
     // High-score persistence is best effort; gameplay should keep running.
@@ -276,6 +327,10 @@ const saveStoredScoreRecords = (entries: StoredHighScoreEntry[]): void => {
 };
 
 const submitPendingScores = async (): Promise<boolean> => {
+  if (!canUseHighScoreApi()) {
+    return !hasPendingScores();
+  }
+
   const records = loadStoredScoreRecords();
   let changed = false;
   let completed = true;
@@ -292,7 +347,7 @@ const submitPendingScores = async (): Promise<boolean> => {
     }
 
     try {
-      const response = await fetch(highScoreApiBasePath, {
+      const response = await fetchHighScoreApi("", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -304,6 +359,11 @@ const submitPendingScores = async (): Promise<boolean> => {
           submittedAt: record.submittedAt,
         }),
       });
+
+      if (!response) {
+        completed = false;
+        break;
+      }
 
       if (isTerminalSyncRejection(response.status)) {
         record.syncState = "local";
@@ -348,10 +408,14 @@ const submitPendingScores = async (): Promise<boolean> => {
 };
 
 const pullRemoteScores = async (): Promise<boolean> => {
-  try {
-    const response = await fetch(highScoreApiBasePath);
+  if (!canUseHighScoreApi()) {
+    return true;
+  }
 
-    if (!response.ok) {
+  try {
+    const response = await fetchHighScoreApi();
+
+    if (!response?.ok) {
       return false;
     }
 
@@ -408,6 +472,20 @@ const upsertScoreRecords = (
   return [...byId.values()];
 };
 
+const trimStoredScoreRecords = (
+  entries: StoredHighScoreEntry[]
+): StoredHighScoreEntry[] => {
+  const pending = entries
+    .filter((entry) => entry.syncState === "pending")
+    .sort(sortHighScores);
+  const cached = entries
+    .filter((entry) => entry.syncState !== "pending")
+    .sort(sortHighScores)
+    .slice(0, Math.max(0, maxCachedHighScores - pending.length));
+
+  return [...pending, ...cached].slice(0, maxCachedHighScores);
+};
+
 const normalizeStoredEntry = (
   entry: HighScoreEntry | StoredHighScoreEntry
 ): StoredHighScoreEntry => {
@@ -450,6 +528,50 @@ const normalizeSyncState = (
 
 const isTerminalSyncRejection = (status: number): boolean =>
   status === 401 || status === 422;
+
+const markHighScoreApiOffline = (): void => {
+  highScoreApiOffline = true;
+  highScoreApiLastProbeAt = Date.now();
+};
+
+const canUseHighScoreApi = (): boolean => !isApiDisabledByConfig();
+
+const isApiDisabledByConfig = (): boolean => getApiMode() === "offline";
+
+const getApiMode = (): "auto" | "offline" => {
+  const configuredMode = import.meta.env.VITE_API_MODE;
+
+  return configuredMode === "offline" ? "offline" : "auto";
+};
+
+const fetchHighScoreApi = async (
+  path = "",
+  init?: RequestInit
+): Promise<Response | null> => {
+  if (!canUseHighScoreApi()) {
+    return null;
+  }
+
+  const controller =
+    typeof AbortController === "undefined" ? null : new AbortController();
+  const timeout =
+    controller === null
+      ? undefined
+      : setTimeout(() => controller.abort(), highScoreApiTimeoutMs);
+
+  try {
+    return await fetch(`${highScoreApiBasePath}${path}`, {
+      ...init,
+      signal: controller?.signal ?? init?.signal,
+    });
+  } catch {
+    return null;
+  } finally {
+    if (timeout !== undefined) {
+      clearTimeout(timeout);
+    }
+  }
+};
 
 const toHighScoreEntry = (entry: HighScoreEntry): HighScoreEntry => ({
   createdAt: entry.createdAt,

--- a/src/game/index.ts
+++ b/src/game/index.ts
@@ -1890,6 +1890,7 @@ export class TimePilot {
       `Loops: ${stats.loops}`,
       `Restarts: ${stats.restarts}`,
       `Enemies: ${stats.enemiesDestroyed}`,
+      `Bosses: ${stats.bossesDefeated}`,
       `Shots: ${stats.shotsHit}/${stats.shotsFired}`,
       `Bonuses: ${stats.bonusesCollected}`,
       `Lives lost: ${stats.livesLost}`,

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,3 +1,7 @@
 /// <reference types="vite/client" />
 
+interface ImportMetaEnv {
+  readonly VITE_API_MODE?: "auto" | "offline";
+}
+
 declare const __TIME_PILOT_VERSION__: string;


### PR DESCRIPTION
This pull request introduces robust offline support and data integrity validation for high score syncing, enhancing both the reliability and security of score submissions. It ensures the app gracefully handles offline/blocked API scenarios, prevents tampered scores from being submitted, and adds a lightweight integrity envelope to local score storage and sync. The documentation and tests are updated to reflect these changes.

**Offline support and API configuration:**

* Added support for an `offline` API mode via the `VITE_API_MODE` environment variable, allowing the app to operate fully offline and skip API calls when configured. The app now detects API unavailability, shows an offline sync indicator, and periodically probes for API availability. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R83-R93) [[2]](diffhunk://#diff-5b224b96cf90cf7ad585335784942ffbef2d23ce5f086e5eebf108534453e741R12-R73) [[3]](diffhunk://#diff-5b224b96cf90cf7ad585335784942ffbef2d23ce5f086e5eebf108534453e741R189-R197) [[4]](diffhunk://#diff-5b224b96cf90cf7ad585335784942ffbef2d23ce5f086e5eebf108534453e741R274-R290) [[5]](diffhunk://#diff-a62f825a4dcbc882c74d26fce055b709235f7f596fc30ce690182f37676d7954R182-R210)

**High score data integrity and validation:**

* Implemented a high score integrity envelope: each pending local score now carries a checksum and hash-based integrity fields, preventing tampered or manually edited scores from being submitted to the backend. The backend validates this envelope and downgrades invalid scores to local-only. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L109-R117) [[2]](diffhunk://#diff-18ed6fb12f3b5dc0e2d9e1f09d4614c6b745c12f3ab7e9ffe847b97f1a7e4818R16-R19) [[3]](diffhunk://#diff-18ed6fb12f3b5dc0e2d9e1f09d4614c6b745c12f3ab7e9ffe847b97f1a7e4818L343-R347) [[4]](diffhunk://#diff-18ed6fb12f3b5dc0e2d9e1f09d4614c6b745c12f3ab7e9ffe847b97f1a7e4818R357-R360) [[5]](diffhunk://#diff-18ed6fb12f3b5dc0e2d9e1f09d4614c6b745c12f3ab7e9ffe847b97f1a7e4818R440-R518) [[6]](diffhunk://#diff-5b224b96cf90cf7ad585335784942ffbef2d23ce5f086e5eebf108534453e741R12-R73) [[7]](diffhunk://#diff-5b224b96cf90cf7ad585335784942ffbef2d23ce5f086e5eebf108534453e741L189-R262) [[8]](diffhunk://#diff-5b224b96cf90cf7ad585335784942ffbef2d23ce5f086e5eebf108534453e741R367-R399)

**Sync logic and local storage improvements:**

* Improved sync logic to avoid resubmitting cached remote scores, keep pending local submissions when caching a full remote table, and trim stored scores to the configured limits. [[1]](diffhunk://#diff-5b224b96cf90cf7ad585335784942ffbef2d23ce5f086e5eebf108534453e741L189-R262) [[2]](diffhunk://#diff-5b224b96cf90cf7ad585335784942ffbef2d23ce5f086e5eebf108534453e741L271-R351) [[3]](diffhunk://#diff-a62f825a4dcbc882c74d26fce055b709235f7f596fc30ce690182f37676d7954R254-R382)

**Testing and documentation:**

* Expanded tests to cover offline mode, integrity checks, and sync logic edge cases. Updated documentation to describe offline mode, fallback behavior, and the new integrity validation. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R83-R93) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L109-R117) [[3]](diffhunk://#diff-a62f825a4dcbc882c74d26fce055b709235f7f596fc30ce690182f37676d7954R29-R30) [[4]](diffhunk://#diff-a62f825a4dcbc882c74d26fce055b709235f7f596fc30ce690182f37676d7954R182-R210) [[5]](diffhunk://#diff-a62f825a4dcbc882c74d26fce055b709235f7f596fc30ce690182f37676d7954R254-R382)

**Miscellaneous:**

* Bumped version to `22.1.0`.