### PR TITLE
Enhance server functionality to serve static files and add production start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,18 @@ If `DATABASE_URL` already contains an SSL option, that URL wins and
 `DATABASE_SSL` is ignored. This avoids accidentally overriding hosted-provider
 connection strings that already include their SSL requirements.
 
+For a single DigitalOcean Web Service that hosts both the game and the
+high-score API, use:
+
+```bash
+Build command: npm run build
+Run command: npm start
+```
+
+`npm start` serves the built `dist/` site and the `/api/high-scores` endpoints
+from the same Node process, so visiting the DigitalOcean app root should open
+the Time Pilot site rather than the JSON API fallback.
+
 If PostgreSQL is unavailable or not configured, the API falls back to
 `data/high-scores.json`. That fallback is useful for local development and small
 self-hosted installs; production deployments should use PostgreSQL and a stable

--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -38,6 +38,8 @@
 - Added local `.env` loading and hosted-PostgreSQL SSL handling for the
   high-score API, including DigitalOcean-style URLs that already carry their
   own SSL mode.
+- Added a production `npm start` server that serves the built game, Storybook
+  showcase, and high-score API from one DigitalOcean web service.
 - Added single-use signed run receipts and server-side plausibility checks for
   best-effort protection against fake remote high score submissions.
 - Added a satellite connection indicator for high-score API state, covering

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "time-pilot",
-  "version": "22.12.1",
+  "version": "22.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "time-pilot",
-      "version": "22.12.1",
+      "version": "22.13.0",
       "dependencies": {
         "pg": "^8.21.0",
         "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "time-pilot",
   "private": true,
-  "version": "22.12.1",
+  "version": "22.13.0",
   "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build && npm run build:storybook && node scripts/prune-release-assets.mjs",
+    "start": "node server/high-score-server.mjs",
     "preview": "vite preview",
     "api": "node server/high-score-server.mjs",
     "typecheck": "tsc --noEmit --noImplicitAny true",

--- a/server/high-score-server.mjs
+++ b/server/high-score-server.mjs
@@ -1,10 +1,10 @@
 /* global Buffer, console, process */
 
 import { createHmac, randomUUID, timingSafeEqual } from "node:crypto";
-import { existsSync, readFileSync } from "node:fs";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { createReadStream, existsSync, readFileSync } from "node:fs";
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
-import { dirname, resolve } from "node:path";
+import { dirname, extname, resolve, sep } from "node:path";
 import { fileURLToPath, URL } from "node:url";
 import pg from "pg";
 
@@ -16,6 +16,7 @@ const envFilePaths = [
   resolve(__dirname, "../.env"),
 ];
 const apiRuntimeFilePath = resolve(__dirname, "../.time-pilot/high-score-api.json");
+const staticRootPath = resolve(__dirname, "../dist");
 const jsonStorePath = resolve(__dirname, "../data/high-scores.json");
 const maxBodyBytes = 64 * 1024;
 const maxGameEra = 5;
@@ -83,6 +84,18 @@ const preferredPort = Number.parseInt(process.env.PORT ?? "8787", 10);
 const serverSecret =
   process.env.HIGH_SCORE_SECRET ?? `dev-secret-${process.pid}-${Date.now()}`;
 const corsOrigin = process.env.CORS_ORIGIN ?? "";
+const contentTypes = {
+  ".css": "text/css; charset=utf-8",
+  ".html": "text/html; charset=utf-8",
+  ".ico": "image/x-icon",
+  ".js": "text/javascript; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".ogg": "audio/ogg",
+  ".png": "image/png",
+  ".svg": "image/svg+xml",
+  ".webmanifest": "application/manifest+json; charset=utf-8",
+  ".woff2": "font/woff2",
+};
 
 const jsonState = {
   runs: [],
@@ -372,12 +385,106 @@ const server = createServer(async (request, response) => {
       return;
     }
 
+    if (request.method === "GET" || request.method === "HEAD") {
+      await handleStaticRequest(request, response);
+      return;
+    }
+
     sendJson(response, 404, { error: "not_found" });
   } catch (error) {
     console.error("High score API error", error);
     sendJson(response, 500, { error: "server_error" });
   }
 });
+
+const handleStaticRequest = async (request, response) => {
+  const filePath = getStaticFilePath(request.url ?? "/");
+
+  if (!filePath) {
+    sendJson(response, 404, { error: "not_found" });
+    return;
+  }
+
+  try {
+    const fileStat = await stat(filePath);
+
+    if (!fileStat.isFile()) {
+      sendJson(response, 404, { error: "not_found" });
+      return;
+    }
+
+    response.writeHead(200, {
+      "Cache-Control": getStaticCacheControl(filePath),
+      "Content-Length": fileStat.size,
+      "Content-Type": getContentType(filePath),
+    });
+
+    if (request.method === "HEAD") {
+      response.end();
+      return;
+    }
+
+    createReadStream(filePath)
+      .on("error", (error) => {
+        console.error("Static file response failed", error);
+
+        if (!response.headersSent) {
+          sendJson(response, 500, { error: "server_error" });
+          return;
+        }
+
+        response.destroy(error);
+      })
+      .pipe(response);
+  } catch {
+    sendJson(response, 404, { error: "not_found" });
+  }
+};
+
+const getStaticFilePath = (requestUrl) => {
+  const url = new URL(requestUrl, "http://localhost");
+  const pathname = decodeURIComponent(url.pathname);
+  const routePath = getStaticRoutePath(pathname);
+  const filePath = resolve(staticRootPath, routePath);
+
+  return isStaticFilePath(filePath) ? filePath : undefined;
+};
+
+const getStaticRoutePath = (pathname) => {
+  if (pathname === "/" || pathname === "") {
+    return "index.html";
+  }
+
+  if (pathname === "/about" || pathname === "/about/") {
+    return "about/index.html";
+  }
+
+  if (pathname === "/pwa" || pathname === "/pwa/") {
+    return "pwa/index.html";
+  }
+
+  if (pathname === "/stories" || pathname === "/stories/") {
+    return "stories/index.html";
+  }
+
+  if (pathname.endsWith("/")) {
+    return `${pathname.slice(1)}index.html`;
+  }
+
+  return pathname.slice(1);
+};
+
+const isStaticFilePath = (filePath) =>
+  filePath === staticRootPath || filePath.startsWith(`${staticRootPath}${sep}`);
+
+const getContentType = (filePath) =>
+  contentTypes[extname(filePath).toLowerCase()] ??
+  "application/octet-stream";
+
+const getStaticCacheControl = (filePath) =>
+  filePath.includes(`${sep}assets${sep}`)
+    ? "public, max-age=31536000, immutable"
+    : "public, max-age=300";
 
 const handleListScores = async (response) => {
   const store = await getStore();


### PR DESCRIPTION
This pull request introduces a production-ready server setup that allows the built game, Storybook showcase, and high-score API to be served together from a single DigitalOcean web service. The main changes focus on adding static file serving to the existing API server, updating documentation, and incrementing the package version.

**Production server enhancements:**

* Added a new `npm start` script to `package.json` that runs the unified production server (`server/high-score-server.mjs`).
* The server now serves static files from the built `dist/` directory, including game assets and Storybook, alongside the `/api/high-scores` endpoint. Static routing supports clean URLs for main routes and assets. [[1]](diffhunk://#diff-18ed6fb12f3b5dc0e2d9e1f09d4614c6b745c12f3ab7e9ffe847b97f1a7e4818L4-R7) [[2]](diffhunk://#diff-18ed6fb12f3b5dc0e2d9e1f09d4614c6b745c12f3ab7e9ffe847b97f1a7e4818R19) [[3]](diffhunk://#diff-18ed6fb12f3b5dc0e2d9e1f09d4614c6b745c12f3ab7e9ffe847b97f1a7e4818R87-R98) [[4]](diffhunk://#diff-18ed6fb12f3b5dc0e2d9e1f09d4614c6b745c12f3ab7e9ffe847b97f1a7e4818R388-R488)

**Documentation updates:**

* Updated `README.md` with instructions for deploying the unified server on DigitalOcean, clarifying that both the game and API are now served from the same process.
* Added a changelog entry in `WHATSNEW.md` describing the new production server capability.

**Other changes:**

* Bumped the project version to `22.13.0` to reflect the new features.