### PR TITLE
Feature/engine separation 3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,13 +36,50 @@ jobs:
           npm test
           npm run lint
           npm run typecheck
-          npm run build
 
       - name: Read package version
         id: package
         run: |
           version=$(node -p "require('./package.json').version")
           echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Build downloadable release
+        env:
+          VITE_API_MODE: offline
+          VITE_BASE_PATH: ./
+        run: npm run build
+
+      - name: Package downloadable release
+        env:
+          VERSION: ${{ steps.package.outputs.version }}
+        run: |
+          set -euo pipefail
+          archive="time-pilot-v${VERSION}-web.zip"
+
+          mkdir -p release-assets
+          cat > dist/README.txt <<EOF
+          Time Pilot v${VERSION}
+
+          This archive contains the built web version of Time Pilot.
+
+          To play locally, extract the archive, serve the extracted directory
+          with any static web server, then open the local URL in your browser.
+
+          Choose one static-server command:
+
+          Option 1, with npm:
+            npx serve .
+
+          Option 2, with Python:
+            python3 -m http.server 8080
+
+          Opening index.html directly from the file system is not recommended
+          because browser security rules can block module, asset, and PWA
+          behavior.
+          EOF
+
+          cd dist
+          zip -r "../release-assets/${archive}" .
 
       - name: Create tag and release
         env:
@@ -66,6 +103,9 @@ jobs:
             echo "Release ${tag} already exists."
           else
             gh release create "${tag}" \
+              "release-assets/time-pilot-v${VERSION}-web.zip" \
               --title "Time Pilot ${tag}" \
-              --notes "Release ${tag} from ${GITHUB_SHA}."
+              --notes "Release ${tag} from ${GITHUB_SHA}.
+
+          Download \`time-pilot-v${VERSION}-web.zip\`, extract it, serve the extracted directory with a local static web server, and open the local URL in your browser."
           fi

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🕹️ Time Pilot
 
-**Time Pilot** is a modernized React + TypeScript rebuild of an older browser-game prototype. The game still renders through a pixel-art canvas engine, but it now lives inside a Vite application with typed game modules, React lifecycle integration, SCSS module styling, CI checks, GitHub Pages deployment, and release automation.
+**Time Pilot** is a modernized React + TypeScript rebuild of an older browser-game prototype. The game renders through the published Arcade-Engine canvas package, and it now lives inside a Vite application with typed game modules, React lifecycle integration, SCSS module styling, CI checks, GitHub Pages deployment, and release automation.
 
 ## 🕰️ Project History
 
@@ -13,10 +13,11 @@ game properly while preserving the original canvas-era feel.
 
 - 🎮 Canvas-based arcade gameplay hosted inside React.
 - ⚛️ Thin React integration via `useTimePilot`.
-- 🧠 Typed game engine modules with explicit game context injection.
+- 🧠 Typed game modules with explicit game context injection.
+- 📦 Canvas, ticker, audio, helper, viewport, and debug-vector primitives supplied by [`arcade-engine`](https://www.npmjs.com/package/arcade-engine).
 - 🎨 Component-scoped SCSS modules for the React shell, canvas host, and update overlay.
 - 🧱 Feature-oriented source layout under `src/game`.
-- 🧪 Vitest coverage for engine helpers, controllers, menus, factories, the game host, and React integration.
+- 🧪 Vitest coverage for Arcade-Engine integration, controllers, menus, factories, the game host, and React integration.
 - 🎛️ Keyboard, touch, and gamepad controller support.
 - 🧭 Canvas-rendered start/options/debug menus with keyboard, gamepad, mouse, and touch interaction.
 - 🔎 UI zoom and game POV zoom with automatic viewport scaling.
@@ -91,6 +92,25 @@ should not try to contact backend APIs.
 Builds also publish the Storybook reference site to `dist/stories`, so the
 deployed site exposes it under `/stories/`. The showcase page links to that
 route for sprite, menu, preroll, achievement, audio, and UI reference views.
+
+## 📦 Arcade-Engine
+
+Time Pilot now consumes the reusable canvas engine as the public npm package
+[`arcade-engine`](https://www.npmjs.com/package/arcade-engine). The embedded
+`packages/arcade-engine` source has been removed from this repository.
+
+Arcade-Engine provides the browser canvas arena, animation tickers, sound
+wrapper, geometry/collision helpers, viewport helpers, and debug-vector
+rendering used by the game:
+
+```ts
+import { GameArena, Sound, Ticker, helpers } from "arcade-engine";
+```
+
+This repository keeps the Time Pilot-specific orchestration, entities,
+controllers, menus, HUD, achievements, scoring, assets, and React shell. Engine
+changes should happen in the standalone Arcade-Engine package, then be consumed
+here through a normal dependency update.
 
 ## 🏅 High Score Storage
 
@@ -225,12 +245,12 @@ npm run typecheck
 npm run build
 ```
 
-`npm test` runs the Vitest suite in jsdom.
+`npm test` runs the Vitest suite in jsdom and browser-backed Storybook tests.
 
 The test suite covers:
 
-- Engine helpers, collision checks, object cloning, headings, and rotation math.
-- Canvas arena, ticker, and sound wrappers using browser API shims.
+- Arcade-Engine integration points used by Time Pilot, including canvas arena,
+  ticker, sound, helpers, viewport scaling, and debug-vector imports.
 - Keyboard, gamepad, mouse, and touch controller adapters.
 - Menu definitions and state callbacks.
 - Game entities, factories, HUD wiring, and context-backed modules.
@@ -348,7 +368,6 @@ src/
     preroll.ts              Startup author logo, flyby, and menu handoff
     __tests__/              Game module test coverage
     controller/             Keyboard and gamepad input adapters
-    engine/                 Canvas arena, ticker, sound, helpers
     menus/                  Menu definitions
     systems/                Collision, spawning, and rendering systems
     ui-scale.ts             UI and game zoom helpers
@@ -365,14 +384,14 @@ The current design keeps React out of the game loop. This is deliberate.
 - React handles lifecycle, layout, and app composition.
 - `useTimePilot` creates and destroys the game instance.
 - `TimePilot` owns the game context and wires systems together.
-- Entities, factories, controllers, HUD, and engine wrappers are class-based modules.
+- Entities, factories, controllers, HUD, and systems are class-based modules.
 - Collision, spawning, and frame rendering live in dedicated systems under `src/game/systems`.
 - Entities and factories receive explicit context instead of reading a global singleton.
-- Simulation uses a fixed-step 50Hz ticker for movement, spawning, collisions, cleanup, and player actions.
-- Rendering uses a separate FPS-capped animation-frame ticker to paint the latest entity locations and orientations without changing gameplay speed.
+- Simulation uses Arcade-Engine's fixed-step 50Hz ticker for movement, spawning, collisions, cleanup, and player actions.
+- Rendering uses a separate Arcade-Engine FPS-capped animation-frame ticker to paint the latest entity locations and orientations without changing gameplay speed.
 - Game rendering applies pixelated POV scaling separately from HUD and menu UI scaling.
 - Rendering stays canvas-based for predictable paint ordering and frame-by-frame control.
-- Public game utilities, engine entry points, systems, controllers, and React
+- Public game utilities, game entry points, systems, controllers, and React
   bridge components include JSDoc comments for generated API documentation and
   easier maintenance.
 

--- a/README.md
+++ b/README.md
@@ -412,6 +412,39 @@ GitHub Pages builds with:
 VITE_BASE_PATH=/time-pilot/ npm run build
 ```
 
+## 📦 Downloadable Releases
+
+Every `main` release also uploads a built browser bundle to GitHub Releases as
+`time-pilot-vX.Y.Z-web.zip`. The archive contains the production `dist/`
+output, including the playable game and Storybook reference.
+
+To play it locally:
+
+1. Download the `time-pilot-vX.Y.Z-web.zip` asset from the release.
+2. Extract it.
+3. Serve the extracted directory with a static web server.
+4. Open the local URL in your browser.
+
+Choose one static-server command.
+
+With npm:
+
+```bash
+npx serve .
+```
+
+With Python:
+
+```bash
+python3 -m http.server 8080
+```
+
+The release bundle is built with `VITE_BASE_PATH=./` and
+`VITE_API_MODE=offline` so it can run from the extracted directory without
+GitHub Pages routing or the hosted high-score API. Opening `index.html`
+directly with a `file://` URL is not recommended because browser security rules
+can block module, asset, and PWA behavior.
+
 ## 🔢 Versioning
 
 The repo includes a pre-commit hook at `.githooks/pre-commit`.

--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -1,5 +1,17 @@
 # 🗒️ What's New
 
+## 📦 Arcade-Engine Package
+
+- Extracted the reusable canvas, ticker, sound, helper, viewport, and
+  debug-vector layer into the standalone
+  [`arcade-engine`](https://www.npmjs.com/package/arcade-engine) npm package.
+- Switched Time Pilot to consume `arcade-engine` as a normal dependency instead
+  of compiling an embedded `packages/arcade-engine` source tree.
+- Removed the local engine package, Vite alias, TypeScript path mapping, and
+  embedded-engine source tests from this repository.
+- Kept Time Pilot-specific orchestration, entities, controllers, systems,
+  menus, achievements, scoring, assets, and React integration in this project.
+
 ## 🧱 Modern React + TypeScript Foundation
 
 - Migrated the browser-game prototype into a Vite app.
@@ -17,8 +29,9 @@
   - `controller/keyboard1.ts`
 - Removed the unused legacy menu definition modules now that the canvas menu
   system owns root, pause, options, achievements, and debug flows directly.
-- Added shared `types.ts` contracts for game data, controllers, assets, and engine APIs.
-- Added JSDoc coverage across public game utilities, engine entry points,
+- Added shared `types.ts` contracts for game data, controllers, assets, and
+  Arcade-Engine integration APIs.
+- Added JSDoc coverage across public game utilities, game entry points,
   systems, controllers, React bridge components, and maintenance helpers.
 
 ## 🧠 Engine Architecture
@@ -27,7 +40,7 @@
 - Removed the global game data-store singleton.
 - Introduced explicit game context injection for entities, factories, HUD, and input systems.
 - Added `useTimePilot` as the React lifecycle bridge.
-- Converted the remaining prototype-style runtime modules into class-based entities, factories, controllers, engine wrappers, HUD, and menu systems.
+- Converted the remaining prototype-style runtime modules into class-based entities, factories, controllers, HUD, and menu systems.
 - Split collision handling, entity spawning, and frame rendering into dedicated systems.
 - Separated simulation ticking from rendering: game-state calculations run on a 50Hz fixed step, while canvas rendering is independently capped.
 - Removed the old 50,000-tick gameplay pause failsafe so long sessions can keep
@@ -199,7 +212,8 @@
 
 - Added Vitest with jsdom for fast local and CI test runs.
 - Added browser API shims for canvas, media, animation frames, and gamepads.
-- Covered core engine helpers, arena behavior, ticker timing, sound wrappers, controllers, menus, factories, entities, HUD wiring, the `TimePilot` class, and the React host component.
+- Covered Arcade-Engine integration, controllers, menus, factories, entities,
+  HUD wiring, the `TimePilot` class, and the React host component.
 - Covered menu back navigation, paused root-menu resume behavior, debug level select previews, zoom controls, and keyboard/gamepad menu shortcuts.
 - Added coverage for touch menu routing and scrolling, staged-only hook logic,
   update menu availability, filter editing baselines, time-warp previews, and

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "time-pilot",
-  "version": "30.0.0",
+  "version": "30.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "time-pilot",
-      "version": "30.0.0",
+      "version": "30.0.1",
       "dependencies": {
         "arcade-engine": "^2.29.0",
         "classnames": "^2.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "time-pilot",
-  "version": "30.0.1",
+  "version": "30.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "time-pilot",
-      "version": "30.0.1",
+      "version": "30.0.2",
       "dependencies": {
         "arcade-engine": "^2.29.0",
         "classnames": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "time-pilot",
   "private": true,
-  "version": "30.0.0",
+  "version": "30.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "time-pilot",
   "private": true,
-  "version": "30.0.1",
+  "version": "30.0.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -259,7 +259,7 @@ function App() {
             <p className={styles.heroSummary}>
               A modern React + TypeScript port of a canvas arcade game, packaged
               as a playable browser demo and installable standalone PWA with
-              typed engine modules, achievements, skippable startup preroll,
+              Arcade-Engine primitives, achievements, skippable startup preroll,
               fullscreen play entry, paused session restore, configurable
               controls, and automated release checks.
             </p>
@@ -287,7 +287,7 @@ function App() {
           >
             <div className={styles.gamePanelHeader}>
               <span>Live build</span>
-              <span>Canvas engine</span>
+              <span>Arcade-Engine</span>
             </div>
             <TimePilotGame />
           </section>

--- a/src/stories/Audio.stories.tsx
+++ b/src/stories/Audio.stories.tsx
@@ -255,7 +255,7 @@ const AudioScene = ({
   return (
     <div className={"storybook-surface"}>
       <section className={"storybook-section"}>
-        <p className={"storybook-eyebrow"}>{"Audio"}</p>
+        <p className={"storybook-eyebrow"}>{"Arcade-Engine Audio"}</p>
         <h1 className={"storybook-title"}>{"Spatial and Global Sound"}</h1>
         <div className={"storybook-controls"}>
           <button type={"button"} onClick={playSound}>
@@ -334,7 +334,7 @@ const meta = {
     docs: {
       description: {
         component:
-          "Audition global and spatial sound effects through the shared game sound engine.",
+          "Audition global and spatial sound effects through Arcade-Engine's sound wrapper.",
       },
     },
     options: {

--- a/src/stories/Ticker.stories.tsx
+++ b/src/stories/Ticker.stories.tsx
@@ -118,7 +118,7 @@ const TickerStories = () => {
   return (
     <main className={"storybook-surface"}>
       <section className={"storybook-section"}>
-        <p className={"storybook-eyebrow"}>Engine</p>
+        <p className={"storybook-eyebrow"}>Arcade-Engine</p>
         <h1 className={"storybook-title"}>Ticker Demos</h1>
         <div className={"storybook-demo-grid"}>
           <GeneralTickerDemo />
@@ -130,7 +130,7 @@ const TickerStories = () => {
 };
 
 const meta = {
-  title: "Engine/Ticker",
+  title: "Arcade-Engine/Ticker",
   component: TickerStories,
 } satisfies Meta<typeof TickerStories>;
 


### PR DESCRIPTION
This pull request transitions the project to use the standalone `arcade-engine` npm package for all canvas, ticker, sound, and helper functionality, removing the previously embedded engine code. It also updates documentation and release automation to reflect this change, and introduces downloadable release bundles attached to GitHub Releases.

**Arcade-Engine Integration**

* Replaced the embedded engine source with the public `arcade-engine` npm package, updating all references and documentation to point to the new package. The local engine package, Vite alias, TypeScript path mapping, and related tests were removed. [[1]](diffhunk://#diff-fcb406334dd4e4044d79513136b7baf79ba53664ba041dc46a01fffefe8eb200R3-R14) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L16-R20) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R96-R114) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L228-R253) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L351) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L368-R394) [[8]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L262-R262) [[9]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L290-R290) [[10]](diffhunk://#diff-6b3ef5d131403f596d939fbd1ea1544a4c2f91ccad0562dc3e3cc6a05eb97fd8L258-R258) [[11]](diffhunk://#diff-6b3ef5d131403f596d939fbd1ea1544a4c2f91ccad0562dc3e3cc6a05eb97fd8L337-R337) [[12]](diffhunk://#diff-cae9f6ff9402689ef9305873bb83e825482ff4f01aec123f71ce3857b3279088L121-R121) [[13]](diffhunk://#diff-cae9f6ff9402689ef9305873bb83e825482ff4f01aec123f71ce3857b3279088L133-R133) [[14]](diffhunk://#diff-fcb406334dd4e4044d79513136b7baf79ba53664ba041dc46a01fffefe8eb200L20-R34) [[15]](diffhunk://#diff-fcb406334dd4e4044d79513136b7baf79ba53664ba041dc46a01fffefe8eb200L30-R43) [[16]](diffhunk://#diff-fcb406334dd4e4044d79513136b7baf79ba53664ba041dc46a01fffefe8eb200L202-R216)

**Release Automation Improvements**

* Updated the GitHub Actions workflow to build a downloadable web release, package it as a zip archive, and attach it to each release on GitHub. The release notes and instructions were updated to guide users on how to run the game locally from the archive. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L39-R83) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R106-R110) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R415-R447)

**Documentation Updates**

* Updated `README.md` and `WHATSNEW.md` to document the migration to `arcade-engine`, changes to project structure, and new release packaging. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L16-R20) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R96-R114) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L228-R253) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L351) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L368-R394) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R415-R447) [[8]](diffhunk://#diff-fcb406334dd4e4044d79513136b7baf79ba53664ba041dc46a01fffefe8eb200R3-R14) [[9]](diffhunk://#diff-fcb406334dd4e4044d79513136b7baf79ba53664ba041dc46a01fffefe8eb200L20-R34) [[10]](diffhunk://#diff-fcb406334dd4e4044d79513136b7baf79ba53664ba041dc46a01fffefe8eb200L30-R43) [[11]](diffhunk://#diff-fcb406334dd4e4044d79513136b7baf79ba53664ba041dc46a01fffefe8eb200L202-R216)

**Version Bump**

* Bumped the project version to `30.0.2` in `package.json` to reflect these changes.