### PR TITLE
feat: enhance PWA support and streamline release packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,10 @@ jobs:
 
       - name: Build downloadable release
         env:
+          VITE_APP_MODE: pwa
           VITE_API_MODE: offline
           VITE_BASE_PATH: ./
+          VITE_SERVICE_WORKER: disabled
         run: npm run build
 
       - name: Package downloadable release
@@ -56,7 +58,23 @@ jobs:
           set -euo pipefail
           archive="time-pilot-v${VERSION}-web.zip"
 
-          mkdir -p release-assets
+          rm -rf release-assets release-package
+          mkdir -p release-assets release-package
+
+          mkdir -p release-package/assets
+          cp dist/assets/app.css release-package/assets/
+          cp dist/assets/main.js release-package/assets/
+          cp -R dist/fonts release-package/fonts
+          cp -R dist/logos release-package/logos
+          cp -R dist/music release-package/music
+          cp -R dist/sounds release-package/sounds
+          cp -R dist/sprites release-package/sprites
+          sed 's#\.\./#./#g' dist/pwa/index.html \
+            | grep -v 'rel="manifest"' \
+            | grep -v 'rel="icon"' \
+            | grep -v 'rel="apple-touch-icon"' \
+            > release-package/index.html
+
           cat > dist/README.txt <<EOF
           Time Pilot v${VERSION}
 
@@ -74,11 +92,11 @@ jobs:
             python3 -m http.server 8080
 
           Opening index.html directly from the file system is not recommended
-          because browser security rules can block module, asset, and PWA
-          behavior.
+          because browser security rules can block module and asset loading.
           EOF
+          mv dist/README.txt release-package/README.txt
 
-          cd dist
+          cd release-package
           zip -r "../release-assets/${archive}" .
 
       - name: Create tag and release

--- a/README.md
+++ b/README.md
@@ -415,8 +415,9 @@ VITE_BASE_PATH=/time-pilot/ npm run build
 ## 📦 Downloadable Releases
 
 Every `main` release also uploads a built browser bundle to GitHub Releases as
-`time-pilot-vX.Y.Z-web.zip`. The archive contains the production `dist/`
-output, including the playable game and Storybook reference.
+`time-pilot-vX.Y.Z-web.zip`. The archive is a trimmed local-play build: its
+root `index.html` is the full-screen game page, without the landing page, About
+page, Storybook reference, service worker, or installable-PWA metadata.
 
 To play it locally:
 
@@ -439,11 +440,12 @@ With Python:
 python3 -m http.server 8080
 ```
 
-The release bundle is built with `VITE_BASE_PATH=./` and
-`VITE_API_MODE=offline` so it can run from the extracted directory without
-GitHub Pages routing or the hosted high-score API. Opening `index.html`
-directly with a `file://` URL is not recommended because browser security rules
-can block module, asset, and PWA behavior.
+The release bundle is built with `VITE_APP_MODE=pwa`, `VITE_BASE_PATH=./`,
+`VITE_API_MODE=offline`, and service-worker registration disabled so it opens
+directly into the game from the extracted directory without GitHub Pages
+routing, the landing site, Storybook, install prompts, or the hosted high-score
+API. Opening `index.html` directly with a `file://` URL is not recommended
+because browser security rules can block module and asset loading.
 
 ## 🔢 Versioning
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "time-pilot",
-  "version": "30.0.2",
+  "version": "30.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "time-pilot",
-      "version": "30.0.2",
+      "version": "30.0.3",
       "dependencies": {
         "arcade-engine": "^2.29.0",
         "classnames": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "time-pilot",
   "private": true,
-  "version": "30.0.2",
+  "version": "30.0.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/app-routing.ts
+++ b/src/app-routing.ts
@@ -7,7 +7,10 @@ export const isShowcaseMode = (): boolean => {
 export const isPwaRoute = (): boolean => {
   const url = new URL(window.location.href);
 
-  return /\/pwa(?:\/index\.html|\/)?$/.test(url.pathname);
+  return (
+    import.meta.env.VITE_APP_MODE === "pwa" ||
+    /\/pwa(?:\/index\.html|\/)?$/.test(url.pathname)
+  );
 };
 
 export const isAboutRoute = (): boolean => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,7 +9,11 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   </React.StrictMode>
 );
 
-if ("serviceWorker" in navigator && import.meta.env.PROD) {
+if (
+  "serviceWorker" in navigator &&
+  import.meta.env.PROD &&
+  import.meta.env.VITE_SERVICE_WORKER !== "disabled"
+) {
   window.addEventListener("load", () => {
     let updateRefreshRequested = false;
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -2,6 +2,8 @@
 
 interface ImportMetaEnv {
   readonly VITE_API_MODE?: "auto" | "offline";
+  readonly VITE_APP_MODE?: "pwa";
+  readonly VITE_SERVICE_WORKER?: "enabled" | "disabled";
 }
 
 declare const __TIME_PILOT_VERSION__: string;


### PR DESCRIPTION
This pull request updates the release packaging process and documentation to produce a more streamlined, local-playable web build. The downloadable release now opens directly into the game, omitting the landing page, About page, Storybook, service worker, and PWA install metadata. The release workflow and related documentation have been updated to reflect these changes, and the service worker is conditionally disabled in the build.

**Release workflow and packaging improvements:**

* The GitHub Actions release workflow (`.github/workflows/release.yml`) has been updated to:
  - Set `VITE_APP_MODE` to `pwa` and `VITE_SERVICE_WORKER` to `disabled` for the build.
  - Rework the packaging step to create a trimmed release bundle containing only the game assets, and modify `index.html` to remove PWA and install metadata.
  - Move the `README.txt` into the release package and clarify instructions about browser security and asset loading.

**Documentation updates:**

* The `README.md` now describes the downloadable release as a trimmed, local-play build without PWA features, and details the new environment variables and limitations. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L418-R420) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L442-R448)

**Codebase changes for PWA mode and service worker:**

* The `isPwaRoute` function in `src/app-routing.ts` now checks the `VITE_APP_MODE` environment variable, making PWA mode explicit in the build.
* Service worker registration in `src/main.tsx` is now disabled if `VITE_SERVICE_WORKER` is set to `"disabled"`.

**Version bump:**

* Incremented the app version to `30.0.3` in `package.json`.